### PR TITLE
[LCGS] Add parsing the remaining operators and ternary if

### DIFF
--- a/src/lcgs/ast.rs
+++ b/src/lcgs/ast.rs
@@ -3,6 +3,7 @@ use std::fmt::{Display, Formatter};
 use std::rc::Rc;
 
 use crate::lcgs::ast::BinaryOpKind::*;
+use pom::set::Set;
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct Root {
@@ -132,17 +133,26 @@ pub enum BinaryOpKind {
     Implication,
 }
 
-// TODO Binary operators consisting of multiple characters, e.g. "==" or "&&"
-impl From<u8> for BinaryOpKind {
-    fn from(op: u8) -> BinaryOpKind {
+impl From<&[u8]> for BinaryOpKind {
+    fn from(op: &[u8]) -> BinaryOpKind {
         match op {
-            b'+' => Addition,
-            b'*' => Multiplication,
-            b'-' => Subtraction,
-            b'/' => Division,
+            b"+" => Addition,
+            b"*" => Multiplication,
+            b"-" => Subtraction,
+            b"/" => Division,
+            b"==" => Equality,
+            b"!=" => Inequality,
+            b">" => GreaterThan,
+            b"<" => LessThan,
+            b">=" => GreaterOrEqual,
+            b"<=" => LessOrEqual,
+            b"&&" => And,
+            b"||" => Or,
+            b"^" => Xor,
+            b"->" => Implication,
             _ => unimplemented!(
                 "Unrecognized operator '{}'. See 'impl From<u8> for BinaryOpKind' clause.",
-                op
+                String::from_utf8(op.to_vec()).unwrap()
             ),
         }
     }

--- a/src/lcgs/ast.rs
+++ b/src/lcgs/ast.rs
@@ -3,7 +3,6 @@ use std::fmt::{Display, Formatter};
 use std::rc::Rc;
 
 use crate::lcgs::ast::BinaryOpKind::*;
-use pom::set::Set;
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct Root {

--- a/src/lcgs/ast.rs
+++ b/src/lcgs/ast.rs
@@ -102,7 +102,6 @@ pub struct Expr {
 pub enum ExprKind {
     Number(i32),
     Ident(Rc<Identifier>),
-    Negation(Rc<Expr>),
     UnaryOp(UnaryOpKind, Rc<Expr>),
     BinaryOp(BinaryOpKind, Rc<Expr>, Rc<Expr>),
     TernaryIf(Rc<Expr>, Rc<Expr>, Rc<Expr>),
@@ -111,7 +110,7 @@ pub enum ExprKind {
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum UnaryOpKind {
-    LogicalNegation,
+    Not,
     Negation, // eg -4
 }
 

--- a/src/lcgs/parse.rs
+++ b/src/lcgs/parse.rs
@@ -9,14 +9,12 @@ use std::vec::Drain;
 
 use pom::parser::*;
 
+use crate::lcgs::ast::{BinaryOpKind, Expr, ExprKind, Identifier};
 use crate::lcgs::ast::BinaryOpKind::{Addition, Division, Multiplication, Subtraction};
 use crate::lcgs::ast::ExprKind::{BinaryOp, Ident, Number, TernaryIf, UnaryOp};
-use crate::lcgs::ast::{BinaryOpKind, Expr, ExprKind, Identifier};
-use crate::lcgs::precedence::Associativity::RightToLeft;
-use crate::lcgs::precedence::{precedence, Precedence};
-
-use self::pom::set::Set;
 use crate::lcgs::ast::UnaryOpKind::{Negation, Not};
+use crate::lcgs::precedence::{precedence, Precedence};
+use crate::lcgs::precedence::Associativity::RightToLeft;
 
 /// A `Span` describes the position of a slice of text in the original program.
 /// Usually used to describe what text an AST node was created from.
@@ -184,8 +182,9 @@ fn primary_expr() -> Parser<'static, u8, Expr> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::lcgs::ast::BinaryOpKind::{And, Equality, Implication, Inequality, LessThan};
+
+    use super::*;
 
     #[test]
     fn test_ident_01() {

--- a/src/lcgs/parse.rs
+++ b/src/lcgs/parse.rs
@@ -1,8 +1,6 @@
 extern crate pom;
 
-use std::collections::HashMap;
 use std::iter::Peekable;
-use std::ops::Add;
 use std::rc::Rc;
 use std::str::{self, FromStr};
 use std::vec::Drain;
@@ -176,7 +174,7 @@ fn primary_expr() -> Parser<'static, u8, Expr> {
     let ident = identifier().map(|i| Expr {
         kind: Ident(Rc::from(i)),
     });
-    let par = (sym(b'(') * space() * call(expr) - space() - sym(b')'));
+    let par = sym(b'(') * space() * call(expr) - space() - sym(b')');
     neg | not | num | ident | par
 }
 

--- a/src/lcgs/precedence.rs
+++ b/src/lcgs/precedence.rs
@@ -30,6 +30,5 @@ pub fn precedence(op: &BinaryOpKind) -> Precedence {
         Or => Precedence(15, LeftToRight),
         Xor => Precedence(14, LeftToRight),
         Implication => Precedence(13, LeftToRight),
-        _ => unimplemented!("Unknown precedence for '{}'. See precedence.rs", op),
     }
 }

--- a/src/lcgs/precedence.rs
+++ b/src/lcgs/precedence.rs
@@ -23,7 +23,13 @@ pub enum Associativity {
 pub fn precedence(op: &BinaryOpKind) -> Precedence {
     match op {
         Multiplication | Division => Precedence(20, LeftToRight),
-        Addition | Subtraction => Precedence(10, LeftToRight),
+        Addition | Subtraction => Precedence(19, LeftToRight),
+        LessThan | GreaterThan | LessOrEqual | GreaterOrEqual => Precedence(18, LeftToRight),
+        Equality | Inequality => Precedence(17, LeftToRight),
+        And => Precedence(16, LeftToRight),
+        Or => Precedence(15, LeftToRight),
+        Xor => Precedence(14, LeftToRight),
+        Implication => Precedence(13, LeftToRight),
         _ => unimplemented!("Unknown precedence for '{}'. See precedence.rs", op),
     }
 }


### PR DESCRIPTION
Adds binary operators for comparison and logic as well as not and unary negation and ternary if.

Once again, please refer to https://crates.io/crates/pom for documentation on parser combinators.