### PR TITLE
[LCGS] Combine StateVars and StateVarUpdates into one thing

### DIFF
--- a/src/lcgs/ast.rs
+++ b/src/lcgs/ast.rs
@@ -25,7 +25,6 @@ pub enum DeclKind {
     Const(Box<ConstDecl>),
     Label(Box<LabelDecl>),
     StateVar(Box<StateVarDecl>),
-    StateVarChange(Box<StateVarChangeDecl>),
     Player(Box<PlayerDecl>),
     Template(Box<TemplateDecl>),
     Transition(Box<TransitionDecl>),
@@ -39,7 +38,6 @@ impl DeclKind {
             DeclKind::Const(decl) => &decl.name,
             DeclKind::Label(decl) => &decl.name,
             DeclKind::StateVar(decl) => &decl.name,
-            DeclKind::StateVarChange(decl) => &decl.name,
             DeclKind::Player(decl) => &decl.name,
             DeclKind::Template(decl) => &decl.name,
             DeclKind::Transition(decl) => &decl.name,
@@ -130,14 +128,6 @@ pub struct StateVarDecl {
     pub name: Identifier,
     pub range: TypeRange,
     pub initial_value: Expr,
-    pub next_value: Expr,
-}
-
-/// A variable-change declaration. In this declaration the user defines how a variable
-/// changes based on the previous state and the actions taken.
-#[derive(Debug, Eq, PartialEq, Clone)]
-pub struct StateVarChangeDecl {
-    pub name: Identifier,
     pub next_value: Expr,
 }
 

--- a/src/lcgs/ast.rs
+++ b/src/lcgs/ast.rs
@@ -123,12 +123,14 @@ pub struct TemplateDecl {
 }
 
 /// A variable declaration. The state of the CGS is the combination of all variables.
-/// E.g. "`health : [0 .. max_health] init max_health`"
+/// All variable declaration also define how it is updated each transition.
+/// E.g. "`health : [0 .. max_health] init max_health; health' = health - 1`"
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct StateVarDecl {
     pub name: Identifier,
     pub range: TypeRange,
     pub initial_value: Expr,
+    pub next_value: Expr,
 }
 
 /// A variable-change declaration. In this declaration the user defines how a variable

--- a/src/lcgs/ir/eval.rs
+++ b/src/lcgs/ir/eval.rs
@@ -33,11 +33,10 @@ impl<'a> Evaluator<'a> {
             Identifier::Resolved { owner, name } => self
                 .symbols
                 .get(owner, name)
-                .expect("Symbol does not exist. Compiler should have failed already.")
-                .borrow(),
+                .expect("Symbol does not exist. Compiler should have failed already."),
         };
 
-        match &symb.declaration.kind {
+        match &symb.declaration.borrow().kind {
             DeclKind::Const(con) => self.eval(&con.definition),
             DeclKind::Label(_) => unimplemented!(), // TODO Depends on current state
             DeclKind::StateVar(_) => unimplemented!(), // TODO Depends on current state

--- a/src/lcgs/ir/intermediate.rs
+++ b/src/lcgs/ir/intermediate.rs
@@ -54,10 +54,10 @@ impl IntermediateLCGS {
 
         // Collect all symbol names that will be relevant for the game structure
         let labels = fetch_decls(&symbols, |_, rf_decl| {
-            matches!(rf_decl.borrow().declaration.kind, DeclKind::Label(_))
+            matches!(rf_decl.declaration.borrow().kind, DeclKind::Label(_))
         });
         let vars = fetch_decls(&symbols, |_, rf_decl| {
-            matches!(rf_decl.borrow().declaration.kind, DeclKind::StateVar(_))
+            matches!(rf_decl.declaration.borrow().kind, DeclKind::StateVar(_))
         });
 
         let ilcgs = IntermediateLCGS {
@@ -75,7 +75,7 @@ impl IntermediateLCGS {
 /// predicate.
 fn fetch_decls<F>(symbols: &SymbolTable, pred: F) -> Vec<SymbolIdentifier>
 where
-    F: Fn(&SymbolIdentifier, &RefCell<Symbol>) -> bool,
+    F: Fn(&SymbolIdentifier, &Symbol) -> bool,
 {
     symbols
         .iter()
@@ -156,8 +156,8 @@ fn register_decls(symbols: &mut SymbolTable, root: Root) -> Result<Vec<Player>, 
             let template_decl = symbols
                 .get(&Owner::Global, &player_decl.template.name())
                 .expect("Unknown template") // TODO Use custom error
-                .borrow()
                 .declaration
+                .borrow()
                 .clone();
 
             if let DeclKind::Template(template) = template_decl.kind {
@@ -215,9 +215,9 @@ fn check_and_optimize_decls(symbols: &SymbolTable) -> Result<(), ()> {
             name: name.clone(),
         };
 
-        // Reduce the declaration's expression(s)
-        let mut symb = rc_symb.borrow_mut();
-        match symb.declaration.kind.borrow_mut() {
+        // Optimize the declaration's expression(s)
+        let mut declaration = rc_symb.declaration.borrow_mut();
+        match declaration.kind.borrow_mut() {
             DeclKind::Label(label) => {
                 label.name = resolved_name;
                 label.condition =

--- a/src/lcgs/ir/symbol_checker.rs
+++ b/src/lcgs/ir/symbol_checker.rs
@@ -11,7 +11,7 @@ pub enum CheckMode {
     LabelOrTransition,
     /// In StateVarChange mode, identifiers in expressions can only refer constants, state
     /// variables, and transitions (actions)
-    StateVarChange,
+    StateVarUpdate,
 }
 
 impl CheckMode {
@@ -23,7 +23,7 @@ impl CheckMode {
             CheckMode::LabelOrTransition => {
                 matches!(decl_kind, DeclKind::Const(_) | DeclKind::StateVar(_))
             }
-            CheckMode::StateVarChange => {
+            CheckMode::StateVarUpdate => {
                 matches!(decl_kind, DeclKind::Const(_) | DeclKind::StateVar(_) | DeclKind::Transition(_))
             }
         }

--- a/src/lcgs/ir/symbol_checker.rs
+++ b/src/lcgs/ir/symbol_checker.rs
@@ -10,7 +10,7 @@ pub enum CheckMode {
     /// In LabelOrTransition mode, identifiers in expressions can only refer to constants
     /// and state variables.
     LabelOrTransition,
-    /// In StateVarChange mode, identifiers in expressions can only refer constants, state
+    /// In StateVarUpdate mode, identifiers in expressions can only refer constants, state
     /// variables, and transitions (actions)
     StateVarUpdate,
 }
@@ -130,7 +130,6 @@ impl<'a> SymbolChecker<'a> {
                     name: name.clone(),
                 })),
             });
-
         } else {
             // The try_borrow must have failed, which means that the
             // RefCell is currently being mutated by someone. We are only reducing

--- a/src/lcgs/ir/symbol_checker.rs
+++ b/src/lcgs/ir/symbol_checker.rs
@@ -1,5 +1,6 @@
 use crate::lcgs::ast::{BinaryOpKind, DeclKind, Expr, ExprKind, Identifier, UnaryOpKind};
 use crate::lcgs::ir::symbol_table::{Owner, SymbolIdentifier, SymbolTable};
+use pom::parser::sym;
 
 /// [CheckMode]s control which declaration identifiers are allow to refer to in the [SymbolChecker].
 #[derive(Eq, PartialEq)]
@@ -81,7 +82,6 @@ impl<'a> SymbolChecker<'a> {
                             .get(&Owner::Global, &name)
                             // TODO Use custom error
                             .expect("Expected constant expression. Found unknown constant.")
-                            .borrow()
                     }
                 } else {
                     if let Some(player_name) = owner {
@@ -95,45 +95,59 @@ impl<'a> SymbolChecker<'a> {
                         let owner = Owner::Player(player_name.to_string());
                         self.symbols
                             .get(&owner, &name)
-                                // TODO Use custom error
+                            // TODO Use custom error
                             .expect("Unknown identifier. The player does not own a declaration of that name")
                     } else {
                         // Player is omitted. Assume it is scope owner. If not, then try global.
                         self.symbols
                             .get(&self.scope_owner, &name)
                             .or_else(|| self.symbols.get(&Owner::Global, &name))
-                                // TODO Use custom error
+                            // TODO Use custom error
                             .expect("Unknown identifier, neither declared locally or globally")
                     }
-                    .try_borrow()
-                        // If the try_borrow fails, it means that the RefCell is currently being
-                        // mutated by someone. We are only reducing one declaration at a time,
-                        // so the declaration must have an identifier referring to itself.
-                    .expect("Declaration refers to itself.") // TODO Use custom error
                 }
             }
             // Already resolved once ... which should never happen.
             Identifier::Resolved { .. } => panic!("Identifier was already resolved once."),
         };
 
-        // Check if symbol is allow to be reference in this mode
-        if !self.mode.allows(&symb.declaration.kind) {
-            return Err(());
-        }
+        if let Ok(declaration) = &symb.declaration.try_borrow() {
+            // Check if symbol is allow to be reference in this mode
+            if !self.mode.allows(&declaration.kind) {
+                return Err(());
+            }
 
-        if let DeclKind::Const(con) = &symb.declaration.kind {
-            // If symbol points to a constant declaration we can inline the value
-            return self.check(&con.definition);
-        }
+            if let DeclKind::Const(con) = &declaration.kind {
+                // If symbol points to a constant declaration we can inline the value
+                return self.check(&con.definition);
+            }
 
-        // Identifier is okay. Return a resolved identifier where owner is specified.
-        let SymbolIdentifier { owner, name } = &symb.identifier;
-        return Ok(Expr {
-            kind: ExprKind::OwnedIdent(Box::new(Identifier::Resolved {
-                owner: owner.clone(),
-                name: name.clone(),
-            })),
-        });
+            // Identifier is okay. Return a resolved identifier where owner is specified.
+            let SymbolIdentifier { owner, name } = &symb.identifier;
+            return Ok(Expr {
+                kind: ExprKind::OwnedIdent(Box::new(Identifier::Resolved {
+                    owner: owner.clone(),
+                    name: name.clone(),
+                })),
+            });
+
+        } else {
+            // The try_borrow must have failed, which means that the
+            // RefCell is currently being mutated by someone. We are only reducing
+            // one declaration at a time, so the declaration must have an identifier
+            // referring to the declaration itself. This is only okay, if we are
+            // in CheckMode::StateVarUpdate. In such case we can return immediately.
+            if self.mode == CheckMode::StateVarUpdate {
+                return Ok(Expr {
+                    kind: ExprKind::OwnedIdent(Box::new(Identifier::Resolved {
+                        owner: symb.identifier.owner.clone(),
+                        name: symb.identifier.name.clone(),
+                    })),
+                });
+            } else {
+                panic!("Declaration refers to itself.") // TODO Use custom error
+            }
+        };
     }
 
     /// Optimizes the given unary operator and checks the operand

--- a/src/lcgs/ir/symbol_table.rs
+++ b/src/lcgs/ir/symbol_table.rs
@@ -21,7 +21,7 @@ impl Display for SymbolIdentifier {
 #[derive(Debug)]
 pub struct Symbol {
     pub identifier: SymbolIdentifier,
-    pub declaration: Decl,
+    pub declaration: RefCell<Decl>,
 }
 
 /// A `SymbolTable` keeps track of registered symbols and their properties.
@@ -29,7 +29,7 @@ pub struct Symbol {
 /// player. Hence, keys are `SymbolIdentifier`s consisting of both an
 /// owner and a name.
 pub struct SymbolTable {
-    symbols: HashMap<SymbolIdentifier, RefCell<Symbol>>,
+    symbols: HashMap<SymbolIdentifier, Symbol>,
 }
 
 impl SymbolTable {
@@ -46,20 +46,20 @@ impl SymbolTable {
     /// Creates and inserts a symbol for the given declaration for the given owner with the
     /// given name. If the name is already associated with a different symbol, the previous
     /// symbol is returned.
-    pub fn insert(&mut self, owner: &Owner, name: &str, decl: Decl) -> Option<RefCell<Symbol>> {
+    pub fn insert(&mut self, owner: &Owner, name: &str, decl: Decl) -> Option<Symbol> {
         let symb_id = SymbolIdentifier {
             owner: owner.clone(),
             name: name.to_string(),
         };
         let symb = Symbol {
             identifier: symb_id.clone(),
-            declaration: decl,
+            declaration: RefCell::new(decl),
         };
-        self.symbols.insert(symb_id, RefCell::new(symb))
+        self.symbols.insert(symb_id, symb)
     }
 
     /// Get the symbol associated with the given owner and name, if it exists.
-    pub fn get(&self, owner: &Owner, name: &str) -> Option<&RefCell<Symbol>> {
+    pub fn get(&self, owner: &Owner, name: &str) -> Option<&Symbol> {
         let symb_id = SymbolIdentifier {
             owner: owner.clone(),
             name: name.to_string(),
@@ -67,7 +67,7 @@ impl SymbolTable {
         self.symbols.get(&symb_id)
     }
 
-    pub fn iter(&self) -> std::collections::hash_map::Iter<'_, SymbolIdentifier, RefCell<Symbol>> {
+    pub fn iter(&self) -> std::collections::hash_map::Iter<'_, SymbolIdentifier, Symbol> {
         self.into_iter()
     }
 }
@@ -79,8 +79,8 @@ impl Default for SymbolTable {
 }
 
 impl<'a> IntoIterator for &'a SymbolTable {
-    type Item = (&'a SymbolIdentifier, &'a RefCell<Symbol>);
-    type IntoIter = std::collections::hash_map::Iter<'a, SymbolIdentifier, RefCell<Symbol>>;
+    type Item = (&'a SymbolIdentifier, &'a Symbol);
+    type IntoIter = std::collections::hash_map::Iter<'a, SymbolIdentifier, Symbol>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.symbols.iter()

--- a/src/lcgs/parse.rs
+++ b/src/lcgs/parse.rs
@@ -8,9 +8,7 @@ use std::vec::Drain;
 use pom::parser::*;
 
 use crate::lcgs::ast::DeclKind::*;
-use crate::lcgs::ast::DeclKind::{
-    Const, Label, Player, StateVar, Template, Transition,
-};
+use crate::lcgs::ast::DeclKind::{Const, Label, Player, StateVar, Template, Transition};
 use crate::lcgs::ast::ExprKind::{BinaryOp, Number, OwnedIdent, TernaryIf, UnaryOp};
 use crate::lcgs::ast::UnaryOpKind::{Negation, Not};
 use crate::lcgs::ast::*;
@@ -206,8 +204,8 @@ fn type_range() -> Parser<'static, u8, TypeRange> {
 fn var_decl() -> Parser<'static, u8, StateVarDecl> {
     let base = identifier() - ws() - sym(b':') - ws() + type_range();
     let init = seq(b"init") * ws() * expr();
-    let change = identifier() - sym(b'\'') - ws() - sym(b'=') - ws() + expr();
-    let whole = base - ws() + init - ws() - sym(b';') - ws() + change;
+    let update = identifier() - sym(b'\'') - ws() - sym(b'=') - ws() + expr();
+    let whole = base - ws() + init - ws() - sym(b';') - ws() + update;
     whole.convert(|(((name, range), initv), (prime, nextv))| {
         if name == prime {
             Ok(StateVarDecl {
@@ -809,7 +807,7 @@ mod tests {
 
     #[test]
     fn test_var_decl_02() {
-        // Var decl where change name does not match
+        // Var decl where update name does not match
         let input = br"health : [0 .. max_health] init max_health; foo' = health";
         let parser = var_decl();
         assert!(parser.parse(input).is_err());


### PR DESCRIPTION
In this PR `StateVarDecl`s and `StateVarUpdate`s (previous `StateVarChange`s) are combined into one declaration, just `StateVarDecl`. This has the following:
* `StateVarDecl`s and `StateVarUpdate`s don't have the same name in the symbol table, so we avoid a lot of trouble there.
* The update clause of a state var declaration must follow right after the variable declaration. That is
```
foo : [0 .. 1] init 0;
foo' = !foo;
```
is okay, but
```
foo : [0 .. 1] init 0;
label is_foo = foo > 0;
foo' = !foo;
```
is not allowed.

Another advantage of this is, that during run, it will be far easier to update variables, as their update definition is in the same struct.