### PR TITLE
Allow LCGS as input game structure

### DIFF
--- a/src/lcgs/ir/intermediate.rs
+++ b/src/lcgs/ir/intermediate.rs
@@ -423,7 +423,7 @@ mod test {
     #[test]
     fn test_symbol_01() {
         // Check if the correct symbols are inserted into the symbol table
-        let input = br"
+        let input = "
         const max_health = 100;
         player anna = gamer;
         player bob = gamer;
@@ -457,7 +457,7 @@ mod test {
     #[test]
     fn test_symbol_02() {
         // State vars can refer to themselves in the update clause
-        let input1 = br"
+        let input1 = "
         foo : [1 .. 10] init 1;
         foo' = foo;
         ";
@@ -466,7 +466,7 @@ mod test {
         assert!(lcgs1.symbols.get(&":global.foo".into()).is_some());
 
         // But other declarations cannot refer to themselves
-        let input2 = br"
+        let input2 = "
         label foo = foo > 0;
         ";
         let lcgs2 =
@@ -477,7 +477,7 @@ mod test {
     #[test]
     fn test_state_translation_01() {
         // Is translation back and forth between state and index correct
-        let input = br"
+        let input = "
         foo : [0 .. 9] init 0;
         foo' = foo;
         bar : [0 .. 5] init 0;
@@ -494,7 +494,7 @@ mod test {
     fn test_state_translation_02() {
         // Is translation back and forth between state and index correct
         // Wack ranges
-        let input = br"
+        let input = "
         foo : [5 .. 23] init 5;
         foo' = foo;
         bar : [3 .. 5] init 3;
@@ -514,7 +514,7 @@ mod test {
     #[test]
     fn test_labels_01() {
         // Are the expected labels present
-        let input = br"
+        let input = "
         foo : [0 .. 9] init 0;
         foo' = foo;
         bar : [0 .. 5] init 0;
@@ -529,7 +529,7 @@ mod test {
     #[test]
     fn test_labels_02() {
         // Are the expected labels present
-        let input = br"
+        let input = "
         foo : [0 .. 9] init 0;
         foo' = foo;
         bar : [0 .. 5] init 0;
@@ -549,7 +549,7 @@ mod test {
     fn test_labels_03() {
         // Are the expected labels present
         // With players and templates
-        let input = br"
+        let input = "
         foo : [0 .. 9] init 0;
         foo' = foo;
         player p1 = something;
@@ -568,7 +568,7 @@ mod test {
     #[test]
     fn test_move_count_01() {
         // Are the expected moves available
-        let input = br"
+        let input = "
         foo : [0 .. 9] init 0;
         foo' = foo;
         player p1 = something1;
@@ -591,7 +591,7 @@ mod test {
     #[test]
     fn test_transition_01() {
         // Can we make transitions as expected when they depend on previous state
-        let input = br"
+        let input = "
         foo : [0 .. 1] init 0;
         foo' = !foo;
         player p = something;
@@ -609,7 +609,7 @@ mod test {
     #[test]
     fn test_transition_02() {
         // Can we make transitions as expected when they depend on player actions
-        let input = br"
+        let input = "
         foo : [0 .. 1] init 0;
         foo' = p.set_foo;
         player p = something;
@@ -628,7 +628,7 @@ mod test {
     #[test]
     fn test_initial_state_01() {
         // Is initial state what we expect?
-        let input = br"
+        let input = "
         foo : [0 .. 1] init 0;
         foo' = foo;
         bar : [0 .. 1] init 1;
@@ -642,7 +642,7 @@ mod test {
     fn test_initial_state_02() {
         // Is initial state what we expect?
         // Wack ranges
-        let input = br"
+        let input = "
         foo : [5 .. 9] init 6;
         foo' = foo;
         bar : [1 .. 6] init 1;

--- a/src/lcgs/ir/intermediate.rs
+++ b/src/lcgs/ir/intermediate.rs
@@ -125,7 +125,7 @@ impl IntermediateLCGS {
     }
 
     /// Returns the initial state of the LCGS game
-    fn initial_state(&self) -> State {
+    pub fn initial_state(&self) -> State {
         let mut res = State(HashMap::new());
         for symb_id in &self.vars {
             let symb = self.symbols.get(symb_id).unwrap();
@@ -137,7 +137,7 @@ impl IntermediateLCGS {
     }
 
     /// Returns the initial state index of the LCGS game
-    fn initial_state_index(&self) -> usize {
+    pub fn initial_state_index(&self) -> usize {
         self.index_of_state(&self.initial_state())
     }
 }

--- a/src/lcgs/ir/intermediate.rs
+++ b/src/lcgs/ir/intermediate.rs
@@ -11,6 +11,7 @@ use crate::lcgs::ir::symbol_table::{Owner, Symbol, SymbolIdentifier, SymbolTable
 
 /// A struct that holds information about players for the intermediate representation
 /// of the lazy game structure
+#[derive(Clone, Debug)]
 pub struct Player {
     name: String,
     actions: Vec<SymbolIdentifier>,
@@ -32,6 +33,7 @@ impl Player {
 
 /// An [IntermediateLCGS] is created from processing an AST and checking the validity of the
 /// declarations.
+#[derive(Clone, Debug)]
 pub struct IntermediateLCGS {
     symbols: SymbolTable,
     labels: Vec<SymbolIdentifier>,

--- a/src/lcgs/ir/intermediate.rs
+++ b/src/lcgs/ir/intermediate.rs
@@ -44,7 +44,7 @@ pub struct IntermediateLCGS {
 impl IntermediateLCGS {
     /// Create an [IntermediateLCGS] from an AST root. All declarations in the resulting
     /// [IntermediateLCGS] are symbol checked and type checked.
-    pub fn create(mut root: Root) -> Result<IntermediateLCGS, ()> {
+    pub fn create(root: Root) -> Result<IntermediateLCGS, ()> {
         let mut symbols = SymbolTable::new();
 
         // Register global decls. Then check and optimize them
@@ -380,7 +380,7 @@ impl GameStructure for IntermediateLCGS {
         let mut state = self.state_from_index(state);
         // To evaluate the next state we assign the actions to either 1 or 0 depending
         // on whether or not the action was taken
-        for (p_index, player) in self.players.iter().enumerate() {
+        for (p_index, _player) in self.players.iter().enumerate() {
             let moves = self.available_moves(&state, p_index);
             for (a_index, a_symb_id) in moves.iter().enumerate() {
                 let val = if choices[p_index] == a_index { 1 } else { 0 };
@@ -408,7 +408,7 @@ impl GameStructure for IntermediateLCGS {
         self.players
             .iter()
             .enumerate()
-            .map(|(i, player)| self.available_moves(&state, i).len() as u32)
+            .map(|(i, _player)| self.available_moves(&state, i).len() as u32)
             .collect()
     }
 }

--- a/src/lcgs/ir/intermediate.rs
+++ b/src/lcgs/ir/intermediate.rs
@@ -430,7 +430,7 @@ mod test {
         // Check if the correct symbols are inserted into the symbol table
         let input = "
         const max_health = 100;
-        player anna = gamer;
+        player alice = gamer;
         player bob = gamer;
 
         template gamer
@@ -446,13 +446,13 @@ mod test {
         let lcgs = IntermediateLCGS::create(parse_lcgs(input).unwrap()).unwrap();
         assert_eq!(lcgs.symbols.len(), 12);
         assert!(lcgs.symbols.get(&":global.max_health".into()).is_some());
-        assert!(lcgs.symbols.get(&":global.anna".into()).is_some());
+        assert!(lcgs.symbols.get(&":global.alice".into()).is_some());
         assert!(lcgs.symbols.get(&":global.bob".into()).is_some());
         assert!(lcgs.symbols.get(&":global.gamer".into()).is_some());
-        assert!(lcgs.symbols.get(&"anna.health".into()).is_some());
-        assert!(lcgs.symbols.get(&"anna.alive".into()).is_some());
-        assert!(lcgs.symbols.get(&"anna.wait".into()).is_some());
-        assert!(lcgs.symbols.get(&"anna.shoot".into()).is_some());
+        assert!(lcgs.symbols.get(&"alice.health".into()).is_some());
+        assert!(lcgs.symbols.get(&"alice.alive".into()).is_some());
+        assert!(lcgs.symbols.get(&"alice.wait".into()).is_some());
+        assert!(lcgs.symbols.get(&"alice.shoot".into()).is_some());
         assert!(lcgs.symbols.get(&"bob.health".into()).is_some());
         assert!(lcgs.symbols.get(&"bob.alive".into()).is_some());
         assert!(lcgs.symbols.get(&"bob.wait".into()).is_some());

--- a/src/lcgs/ir/mod.rs
+++ b/src/lcgs/ir/mod.rs
@@ -1,4 +1,4 @@
 mod eval;
-mod intermediate;
+pub(crate) mod intermediate;
 mod symbol_checker;
 pub mod symbol_table;

--- a/src/lcgs/ir/symbol_table.rs
+++ b/src/lcgs/ir/symbol_table.rs
@@ -18,7 +18,7 @@ impl Display for SymbolIdentifier {
 }
 
 /// A `Symbol` is an identifier and information about it.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Symbol {
     pub identifier: SymbolIdentifier,
     pub declaration: RefCell<Decl>,
@@ -28,6 +28,7 @@ pub struct Symbol {
 /// In this language symbols always belongs to either the global scope or a
 /// player. Hence, keys are `SymbolIdentifier`s consisting of both an
 /// owner and a name.
+#[derive(Clone, Debug)]
 pub struct SymbolTable {
     symbols: HashMap<SymbolIdentifier, Symbol>,
 }

--- a/src/lcgs/ir/symbol_table.rs
+++ b/src/lcgs/ir/symbol_table.rs
@@ -16,10 +16,13 @@ impl From<&str> for SymbolIdentifier {
     /// If the owner is ":global", then the owner will be the global scope.
     fn from(string: &str) -> SymbolIdentifier {
         let split: Vec<&str> = string.split(".").collect();
-        debug_assert!(split.len() == 2, "Invalid symbol identifier. Must consist of an owner and a name.");
+        debug_assert!(
+            split.len() == 2,
+            "Invalid symbol identifier. Must consist of an owner and a name."
+        );
         let owner = match split[0] {
             ":global" => Owner::Global,
-            player => Owner::Player(player.to_string())
+            player => Owner::Player(player.to_string()),
         };
         let name = split[1].to_string();
         SymbolIdentifier { owner, name }
@@ -89,9 +92,10 @@ impl SymbolTable {
 
     /// Consume the symbol table to construct a simple declaration table.
     pub fn solidify(mut self) -> HashMap<SymbolIdentifier, Decl> {
-        self.symbols.drain().map(|(symb_id, symb)| {
-            (symb_id, symb.declaration.into_inner())
-        }).collect()
+        self.symbols
+            .drain()
+            .map(|(symb_id, symb)| (symb_id, symb.declaration.into_inner()))
+            .collect()
     }
 }
 

--- a/src/lcgs/ir/symbol_table.rs
+++ b/src/lcgs/ir/symbol_table.rs
@@ -15,7 +15,7 @@ impl From<&str> for SymbolIdentifier {
     /// Converts a string into a symbol identifier. The string must be on the form "owner.name".
     /// If the owner is ":global", then the owner will be the global scope.
     fn from(string: &str) -> SymbolIdentifier {
-        let split: Vec<&str> = string.split(".").collect();
+        let split: Vec<&str> = string.split('.').collect();
         debug_assert!(
             split.len() == 2,
             "Invalid symbol identifier. Must consist of an owner and a name."

--- a/src/lcgs/mod.rs
+++ b/src/lcgs/mod.rs
@@ -1,4 +1,4 @@
 mod ast;
-mod ir;
+pub(crate) mod ir;
 mod parse;
 mod precedence;

--- a/src/lcgs/mod.rs
+++ b/src/lcgs/mod.rs
@@ -1,4 +1,4 @@
 mod ast;
 pub(crate) mod ir;
-mod parse;
+pub(crate) mod parse;
 mod precedence;

--- a/src/lcgs/parse.rs
+++ b/src/lcgs/parse.rs
@@ -7,6 +7,7 @@ use std::vec::Drain;
 
 use pom::parser::*;
 
+use self::pom::set::Set;
 use crate::lcgs::ast::DeclKind::*;
 use crate::lcgs::ast::DeclKind::{Const, Label, Player, StateVar, Template, Transition};
 use crate::lcgs::ast::ExprKind::{BinaryOp, Number, OwnedIdent, TernaryIf, UnaryOp};
@@ -16,7 +17,6 @@ use crate::lcgs::precedence::Associativity::RightToLeft;
 use crate::lcgs::precedence::{precedence, Precedence};
 use std::borrow::Borrow;
 use std::collections::HashSet;
-use self::pom::set::Set;
 
 // Required for static allocation of a hashset
 lazy_static! {

--- a/src/lcgs/parse.rs
+++ b/src/lcgs/parse.rs
@@ -39,38 +39,38 @@ trait SemiTerminated<'a, I, O: 'a> {
     fn with_semi(self) -> Parser<'a, I, O>;
 }
 
-impl<O: 'static> SemiTerminated<'static, u8, O> for Parser<'static, u8, O> {
+impl<'a, O: 'a> SemiTerminated<'a, u8, O> for Parser<'a, u8, O> {
     /// Declare that the parsing should end with whitespace and a semi-colon
-    fn with_semi(self) -> Parser<'static, u8, O> {
+    fn with_semi(self) -> Parser<'a, u8, O> {
         self - ws() - sym(b';')
     }
 }
 
 /// Parser to parse an ASCII alphabet character
 #[inline]
-fn alpha() -> Parser<'static, u8, u8> {
+fn alpha<'a>() -> Parser<'a, u8, u8> {
     one_of(b"abcdefghijklmnopqrstuvwxyz") | one_of(b"ABCDEFGHIJKLMNOPQRSTUVWXYZ")
 }
 
 /// Parser that parses a single digit 0-9
 #[inline]
-fn digit() -> Parser<'static, u8, u8> {
+fn digit<'a>() -> Parser<'a, u8, u8> {
     one_of(b"0123456789")
 }
 
 /// Parser that parses a single digit 1-9 (not 0)
 #[inline]
-fn non_0_digit() -> Parser<'static, u8, u8> {
+fn non_0_digit<'a>() -> Parser<'a, u8, u8> {
     one_of(b"123456789")
 }
 
 /// Parser that parses 0 or more whitespace characters discards them. Include newlines and tabs.
-fn ws() -> Parser<'static, u8, ()> {
+fn ws<'a>() -> Parser<'a, u8, ()> {
     one_of(b" \t\r\n").repeat(0..).discard()
 }
 
 /// Parser that parses a typical positive integer number
-fn number() -> Parser<'static, u8, Expr> {
+fn number<'a>() -> Parser<'a, u8, Expr> {
     let integer = (non_0_digit() - digit().repeat(0..)) | sym(b'0');
     let parsed = integer
         .collect()
@@ -83,19 +83,19 @@ fn number() -> Parser<'static, u8, Expr> {
 
 /// Parser that parses a symbol name. It must start with an alpha character, but subsequent
 /// characters can be digits or "_" too.
-fn name() -> Parser<'static, u8, String> {
+fn name<'a>() -> Parser<'a, u8, String> {
     let chars = alpha() - (alpha() | digit() | sym(b'_')).repeat(0..);
     chars.collect().convert(|s| String::from_utf8(s.to_vec()))
 }
 
 /// Parser that parses an identifier.
-fn identifier() -> Parser<'static, u8, Identifier> {
+fn identifier<'a>() -> Parser<'a, u8, Identifier> {
     name().map(|name| Identifier::Simple { name })
 }
 
 /// Parser that parses a name with an optional owner and returns an `OwnedIdentifier`.
 /// I.e. "health" or "p1.health"
-fn owned_identifier() -> Parser<'static, u8, Identifier> {
+fn owned_identifier<'a>() -> Parser<'a, u8, Identifier> {
     let identifier = (name() - sym(b'.')).opt() + name();
     identifier
         .with_span()
@@ -103,7 +103,7 @@ fn owned_identifier() -> Parser<'static, u8, Identifier> {
 }
 
 /// Parser that parses binary operators
-fn binop() -> Parser<'static, u8, BinaryOpKind> {
+fn binop<'a>() -> Parser<'a, u8, BinaryOpKind> {
     // When operators share a common prefix the longer one should appear first
     let op = seq(b"+")
         | seq(b"->")
@@ -159,7 +159,7 @@ fn solve_binary_precedence(
 }
 
 /// Parser that parses an expression
-fn expr() -> Parser<'static, u8, Expr> {
+fn expr<'a>() -> Parser<'a, u8, Expr> {
     let tern = binary_expr() - ws() - sym(b'?') - ws() + binary_expr() - ws() - sym(b':') - ws()
         + binary_expr();
     tern.map(|((cond, then), els)| Expr {
@@ -168,7 +168,7 @@ fn expr() -> Parser<'static, u8, Expr> {
 }
 
 /// Parser that parses an expression consisting of binary operators and primary expressions
-fn binary_expr() -> Parser<'static, u8, Expr> {
+fn binary_expr<'a>() -> Parser<'a, u8, Expr> {
     // TODO Spans and combining them
     let binexpr = primary_expr() + (ws() * binop() - ws() + primary_expr()).repeat(0..);
     binexpr.map(|(e, mut es)| solve_binary_precedence(e, 0, &mut es.drain(..).peekable()))
@@ -176,7 +176,7 @@ fn binary_expr() -> Parser<'static, u8, Expr> {
 
 /// Parser that parses an expression with a unary operator
 /// or a primary expression, i.e. number, identifier, or a parenthesised expression
-fn primary_expr() -> Parser<'static, u8, Expr> {
+fn primary_expr<'a>() -> Parser<'a, u8, Expr> {
     let neg = (sym(b'-') * call(primary_expr)).map(|e| Expr {
         kind: UnaryOp(Negation, Box::new(e)),
     });
@@ -192,7 +192,7 @@ fn primary_expr() -> Parser<'static, u8, Expr> {
 }
 
 /// Parser that parses a type range, e.g. "`[0 .. max_health]`"
-fn type_range() -> Parser<'static, u8, TypeRange> {
+fn type_range<'a>() -> Parser<'a, u8, TypeRange> {
     let inner = expr() - ws() - seq(b"..") - ws() + expr();
     let bracked = sym(b'[') * ws() * inner - ws() - sym(b']');
     bracked.map(|(min, max)| TypeRange { min, max })
@@ -200,7 +200,7 @@ fn type_range() -> Parser<'static, u8, TypeRange> {
 
 /// Parser that parses a variable, e.g.
 /// "`health : [0 .. max_health] init max_health`"
-fn var_decl() -> Parser<'static, u8, StateVarDecl> {
+fn var_decl<'a>() -> Parser<'a, u8, StateVarDecl> {
     let base = identifier() - ws() - sym(b':') - ws() + type_range();
     let init = seq(b"init") * ws() * expr();
     let update = identifier() - sym(b'\'') - ws() - sym(b'=') - ws() + expr();
@@ -223,21 +223,21 @@ fn var_decl() -> Parser<'static, u8, StateVarDecl> {
 
 /// Parser that parses a label declaration, e.g.
 /// "`label alive = health > 0`"
-fn label_decl() -> Parser<'static, u8, LabelDecl> {
+fn label_decl<'a>() -> Parser<'a, u8, LabelDecl> {
     let label = seq(b"label") * ws() * identifier() - ws() - sym(b'=') - ws() + expr();
     label.map(|(name, condition)| LabelDecl { condition, name })
 }
 
 /// Parser that parses a const declaration, e.g.
 /// "`const max_health = 1`"
-fn const_decl() -> Parser<'static, u8, ConstDecl> {
+fn const_decl<'a>() -> Parser<'a, u8, ConstDecl> {
     let con = seq(b"const") * ws() * identifier() - ws() - sym(b'=') - ws() + expr();
     con.map(|(name, definition)| ConstDecl { name, definition })
 }
 
 /// Parser that parses a relabelling, e.g.
 /// "`[target1=p2, target2=p3]`"
-fn relabelling() -> Parser<'static, u8, Relabeling> {
+fn relabelling<'a>() -> Parser<'a, u8, Relabeling> {
     let raw_case = identifier() - ws() - sym(b'=') - ws() + identifier();
     let case = raw_case.map(|(prev, new)| RelabelCase {
         prev_name: prev,
@@ -252,7 +252,7 @@ fn relabelling() -> Parser<'static, u8, Relabeling> {
 
 /// Parser that parses a player declaration, e.g.
 /// "`player p1 = shooter [target1=p2, target2=p3]`"
-fn player_decl() -> Parser<'static, u8, PlayerDecl> {
+fn player_decl<'a>() -> Parser<'a, u8, PlayerDecl> {
     let rhs = seq(b"player") * ws() * identifier();
     let lhs = identifier() - ws() + relabelling().opt();
     let whole = rhs - ws() - sym(b'=') - ws() + lhs;
@@ -267,7 +267,7 @@ fn player_decl() -> Parser<'static, u8, PlayerDecl> {
 
 /// Parser that parses a transition declaration, e.g.
 /// "`[shoot_right] health > 0 & target1.health > 0`"
-fn transition_decl() -> Parser<'static, u8, TransitionDecl> {
+fn transition_decl<'a>() -> Parser<'a, u8, TransitionDecl> {
     let name = sym(b'[') * ws() * identifier() - ws() - sym(b']');
     let whole = name - ws() + expr();
     whole.map(|(name, cond)| TransitionDecl {
@@ -277,7 +277,7 @@ fn transition_decl() -> Parser<'static, u8, TransitionDecl> {
 }
 
 /// Parser that parses template declarations
-fn template_decl() -> Parser<'static, u8, TemplateDecl> {
+fn template_decl<'a>() -> Parser<'a, u8, TemplateDecl> {
     let simple_decl = label_decl().map(|ld| Decl {
         kind: Label(Box::new(ld)),
     }) | var_decl().map(|vd| Decl {
@@ -292,7 +292,7 @@ fn template_decl() -> Parser<'static, u8, TemplateDecl> {
 }
 
 /// Parser that parses root level, i.e. all the global declarations
-fn root() -> Parser<'static, u8, Root> {
+fn root<'a>() -> Parser<'a, u8, Root> {
     let simple_decl = label_decl().map(|ld| Decl {
         kind: Label(Box::new(ld)),
     }) | var_decl().map(|vd| Decl {
@@ -311,8 +311,8 @@ fn root() -> Parser<'static, u8, Root> {
 }
 
 /// Parse a LCGS program
-pub fn parse_lcgs(input: &'static [u8]) -> pom::Result<Root> {
-    root().parse(input)
+pub fn parse_lcgs(input: &str) -> pom::Result<Root> {
+    root().parse(input.as_bytes())
 }
 
 #[cfg(test)]

--- a/src/lcgs/parse.rs
+++ b/src/lcgs/parse.rs
@@ -232,12 +232,12 @@ fn primary_expr<'a>() -> Parser<'a, u8, Expr> {
     neg | not | num | min | max | ident | par
 }
 
-fn type_min() -> Parser<'static, u8, Expr> {
+fn type_min<'a>() -> Parser<'a, u8, Expr> {
     let inner = list(call(expr), ws() * sym(b',') - ws());
     let methoded = sym(b'(') * ws() * inner - ws() - sym(b')');
     methoded.map(|min| Expr { kind: Min(min) })
 }
-fn type_max() -> Parser<'static, u8, Expr> {
+fn type_max<'a>() -> Parser<'a, u8, Expr> {
     let inner = list(call(expr), ws() - sym(b',') - ws());
     let methoded = sym(b'(') * ws() * inner - ws() - sym(b')');
     methoded.map(|max| Expr { kind: Max(max) })

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use std::io::{stdout, BufWriter, Read, Write};
 use std::process::exit;
 use std::sync::Arc;
 
-use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
+use clap::{App, Arg, ArgMatches, SubCommand};
 use log::LevelFilter;
 use log4rs::append::console::ConsoleAppender;
 use log4rs::append::file::FileAppender;
@@ -24,7 +24,7 @@ use log4rs::encode::pattern::PatternEncoder;
 
 use crate::atl::dependencygraph::{ATLDependencyGraph, ATLVertex};
 use crate::atl::formula::Phi;
-use crate::atl::gamestructure::{EagerGameStructure, GameStructure};
+use crate::atl::gamestructure::{EagerGameStructure};
 use crate::common::{Edges, VertexAssignment};
 use crate::edg::Vertex;
 use crate::lcgs::ir::intermediate::IntermediateLCGS;

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,7 +107,7 @@ fn model_check(args: &ArgMatches) -> Result<(), Box<dyn Error>> {
 
     let result = match args.value_of("model_type") {
         Some("lcgs") => {
-            model_check_json_cgs(args)
+            model_check_lazy_cgs(args)
         }
         Some("json") => {
             model_check_json_cgs(args)
@@ -165,12 +165,11 @@ fn model_check_lazy_cgs(args: &ArgMatches) -> Result<VertexAssignment, Box<dyn E
     file.read_to_string(&mut formula)?;
     let formula: Arc<Phi> = serde_json::from_str(formula.as_str())?;
 
-    unimplemented!()
-    // Ok(edg::distributed_certain_zero(
-    //     ATLDependencyGraph { game_structure },
-    //     ATLVertex::FULL { state: 0, formula },
-    //     num_cpus::get() as u64,
-    // ))
+    Ok(edg::distributed_certain_zero(
+        ATLDependencyGraph { game_structure },
+        ATLVertex::FULL { state: 0, formula },
+        num_cpus::get() as u64,
+    ))
 }
 
 fn load_lazy_cgs(_path: &str) -> IntermediateLCGS {

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ use crate::common::{Edges, VertexAssignment};
 use crate::edg::Vertex;
 use crate::printer::print_graph;
 use crate::lcgs::ir::intermediate::IntermediateLCGS;
+use crate::lcgs::parse::parse_lcgs;
 
 mod atl;
 mod com;
@@ -172,8 +173,11 @@ fn model_check_lazy_cgs(args: &ArgMatches) -> Result<VertexAssignment, Box<dyn E
     ))
 }
 
-fn load_lazy_cgs(_path: &str) -> IntermediateLCGS {
-    unimplemented!()
+fn load_lazy_cgs(path: &str) -> IntermediateLCGS {
+    let mut file = File::open(path).unwrap();
+    let mut content = String::new();
+    file.read_to_string(&mut content).unwrap();
+    IntermediateLCGS::create(parse_lcgs(&content).unwrap()).unwrap()
 }
 
 /// Define and parse command line arguments

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,10 +22,11 @@ use log4rs::encode::pattern::PatternEncoder;
 
 use crate::atl::dependencygraph::{ATLDependencyGraph, ATLVertex};
 use crate::atl::formula::Phi;
-use crate::atl::gamestructure::EagerGameStructure;
-use crate::common::Edges;
+use crate::atl::gamestructure::{EagerGameStructure, GameStructure};
+use crate::common::{Edges, VertexAssignment};
 use crate::edg::Vertex;
 use crate::printer::print_graph;
+use crate::lcgs::ir::intermediate::IntermediateLCGS;
 
 mod atl;
 mod com;
@@ -50,7 +51,7 @@ impl edg::ExtendedDependencyGraph<i32> for EmptyGraph {
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let args = parse();
+    let args = parse_arguments();
 
     // Load config for logging to stdout and logfile.
     let _handle = log4rs::init_config(get_log4rs_config(
@@ -78,7 +79,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
         ("graph", Some(graph_args)) => {
             let graph = ATLDependencyGraph {
-                game_structure: decode_game_structure(graph_args),
+                game_structure: load_json_cgs(graph_args.value_of("model_type").unwrap()),
             };
 
             let mut file = File::open(graph_args.value_of("formula").unwrap())?;
@@ -101,50 +102,24 @@ fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn decode_game_structure(args: &ArgMatches) -> EagerGameStructure {
-    match args.value_of("model_type") {
+fn model_check(args: &ArgMatches) -> Result<(), Box<dyn Error>> {
+    info!("Model checking on formula: {:?}", args.value_of("formula"));
+
+    let result = match args.value_of("model_type") {
         Some("lcgs") => {
-            // TODO: implement lgcs parser
-            EagerGameStructure {
-                player_count: 0,
-                labeling: vec![],
-                transitions: vec![],
-                moves: vec![],
-            }
+            model_check_json_cgs(args)
         }
         Some("json") => {
-            let mut file = File::open(args.value_of("input_model").unwrap()).unwrap();
-            let mut game_structure = String::new();
-            file.read_to_string(&mut game_structure).unwrap();
-            serde_json::from_str(game_structure.as_str()).unwrap()
+            model_check_json_cgs(args)
         }
         _ => {
             error!(
-                "Model type {:?} not supported!",
+                "Model type '{:?}' not supported!",
                 args.value_of("model_type")
             );
             exit(1)
         }
-    }
-}
-
-fn model_check(args: &ArgMatches) -> Result<(), Box<dyn Error>> {
-    info!("Model checking on formula: {:?}", args.value_of("formula"));
-
-    let game_structure = decode_game_structure(args);
-
-    let mut file = File::open(args.value_of("formula").unwrap())?;
-    let mut formula = String::new();
-    file.read_to_string(&mut formula)?;
-    let formula: Arc<Phi> = serde_json::from_str(formula.as_str())?;
-
-    let graph = ATLDependencyGraph { game_structure };
-
-    let result = edg::distributed_certain_zero(
-        graph,
-        ATLVertex::FULL { state: 0, formula },
-        num_cpus::get() as u64,
-    );
+    }.unwrap();
 
     match args.value_of("output") {
         Some(path) => {
@@ -160,8 +135,50 @@ fn model_check(args: &ArgMatches) -> Result<(), Box<dyn Error>> {
     }
 }
 
+fn model_check_json_cgs(args: &ArgMatches) -> Result<VertexAssignment, Box<dyn Error>> {
+    let game_structure = load_json_cgs(args.value_of("input_model").unwrap());
+
+    let mut file = File::open(args.value_of("formula").unwrap())?;
+    let mut formula = String::new();
+    file.read_to_string(&mut formula)?;
+    let formula: Arc<Phi> = serde_json::from_str(formula.as_str())?;
+
+    Ok(edg::distributed_certain_zero(
+        ATLDependencyGraph { game_structure },
+        ATLVertex::FULL { state: 0, formula },
+        num_cpus::get() as u64,
+    ))
+}
+
+fn load_json_cgs(path: &str) -> EagerGameStructure {
+    let mut file = File::open(path).unwrap();
+    let mut game_structure = String::new();
+    file.read_to_string(&mut game_structure).unwrap();
+    serde_json::from_str(game_structure.as_str()).unwrap()
+}
+
+fn model_check_lazy_cgs(args: &ArgMatches) -> Result<VertexAssignment, Box<dyn Error>> {
+    let game_structure = load_lazy_cgs(args.value_of("input_model").unwrap());
+
+    let mut file = File::open(args.value_of("formula").unwrap())?;
+    let mut formula = String::new();
+    file.read_to_string(&mut formula)?;
+    let formula: Arc<Phi> = serde_json::from_str(formula.as_str())?;
+
+    unimplemented!()
+    // Ok(edg::distributed_certain_zero(
+    //     ATLDependencyGraph { game_structure },
+    //     ATLVertex::FULL { state: 0, formula },
+    //     num_cpus::get() as u64,
+    // ))
+}
+
+fn load_lazy_cgs(_path: &str) -> IntermediateLCGS {
+    unimplemented!()
+}
+
 /// Define and parse command line arguments
-fn parse() -> ArgMatches<'static> {
+fn parse_arguments() -> ArgMatches<'static> {
     fn build_common_arguments<'a>(builder: clap::App<'a, 'a>) -> App<'a, 'a> {
         builder
             .arg(

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ use log4rs::encode::pattern::PatternEncoder;
 
 use crate::atl::dependencygraph::{ATLDependencyGraph, ATLVertex};
 use crate::atl::formula::Phi;
-use crate::atl::gamestructure::{EagerGameStructure};
+use crate::atl::gamestructure::EagerGameStructure;
 use crate::common::{Edges, VertexAssignment};
 use crate::edg::Vertex;
 use crate::lcgs::ir::intermediate::IntermediateLCGS;

--- a/test.lcgs
+++ b/test.lcgs
@@ -1,0 +1,9 @@
+foo : [0 .. 4] init 0;
+foo' = foo == 0 ? 4 : foo - 1;
+
+label is_foo = foo;
+
+player p = waiter;
+template waiter
+    [wait] 1;
+endtemplate


### PR DESCRIPTION
This PR makes it possible to input an LCGS program to the algorithm. I.e. it is now possible to do
```
cargo run -- solver --formula test-formula.json --model test.lcgs --model-type lcgs
```
and have it check if the formula in `test-formula.json` is satisfied in the initial state of the game structure described by `test.lcgs`.

There are still many bad or missing error messages, and the `graph` command only works for eager game structures atm.

Resolves #51 . Depends on #49 .