### PR TITLE
[ATL] Adds more formula term (And, Eventually, Invariant, ...)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ log4rs = "0.12.0"
 serde = { version = "1.0.117", features = ["derive", "rc"] }
 serde_json = "1.0.59"
 lazy_static = "1.4.0"
+joinery = "2.0.0"

--- a/src/atl/dependencygraph.rs
+++ b/src/atl/dependencygraph.rs
@@ -517,7 +517,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
 
                     edges
                 }
-                Phi::EnforcedEventually {
+                Phi::EnforceEventually {
                     players,
                     formula: subformula,
                 } => {
@@ -585,7 +585,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
 
                     edges
                 }
-                Phi::EnforcedAlways {
+                Phi::EnforceAlways {
                     players,
                     formula: subformula,
                 } => {

--- a/src/atl/dependencygraph.rs
+++ b/src/atl/dependencygraph.rs
@@ -291,6 +291,21 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
     fn succ(&self, vert: &ATLVertex) -> HashSet<Edges<ATLVertex>, RandomState> {
         match vert {
             ATLVertex::FULL { state, formula } => match formula.as_ref() {
+                Phi::True => {
+                    let mut edges = HashSet::new();
+
+                    // Empty hyper edge
+                    edges.insert(Edges::HYPER(HyperEdge {
+                        source: vert.clone(),
+                        targets: vec![],
+                    }));
+
+                    edges
+                }
+                Phi::False => {
+                    // No edges
+                    HashSet::new()
+                }
                 Phi::Proposition(prop) => {
                     let props = self.game_structure.labels(vert.state());
                     if props.contains(prop) {

--- a/src/atl/dependencygraph.rs
+++ b/src/atl/dependencygraph.rs
@@ -566,7 +566,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
 
                     edges
                 }
-                Phi::DespiteAlways {
+                Phi::DespiteInvariant {
                     players,
                     formula: subformula,
                 } => {
@@ -598,7 +598,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
 
                     edges
                 }
-                Phi::EnforceAlways {
+                Phi::EnforceInvariant {
                     players,
                     formula: subformula,
                 } => {

--- a/src/atl/dependencygraph.rs
+++ b/src/atl/dependencygraph.rs
@@ -343,6 +343,26 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
 
                     edges
                 }
+                Phi::And(left, right) => {
+                    let mut edges = HashSet::new();
+                    let mut targets = vec![];
+
+                    targets.push(ATLVertex::FULL {
+                        state: *state,
+                        formula: left.clone(),
+                    });
+                    targets.push(ATLVertex::FULL {
+                        state: *state,
+                        formula: right.clone(),
+                    });
+
+                    edges.insert(Edges::HYPER(HyperEdge {
+                        source: vert.clone(),
+                        targets,
+                    }));
+
+                    edges
+                }
                 Phi::DespiteNext { players, formula } => {
                     let inv_players = self.invert_players(players.as_slice());
                     let mut edges = HashSet::new();

--- a/src/atl/dependencygraph.rs
+++ b/src/atl/dependencygraph.rs
@@ -343,7 +343,32 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
 
                     edges
                 }
-                Phi::Next { players, formula } => {
+                Phi::DespiteNext { players, formula } => {
+                    let inv_players = self.invert_players(players.as_slice());
+                    let mut edges = HashSet::new();
+
+                    let moves: Vec<usize> = self
+                        .game_structure
+                        .move_count(*state)
+                        .iter()
+                        .map(|&count| count as usize)
+                        .collect();
+                    let targets: Vec<ATLVertex> =
+                        VarsIterator::new(moves, inv_players.iter().copied().collect())
+                            .map(|pmove| ATLVertex::PARTIAL {
+                                state: *state,
+                                partial_move: pmove,
+                                formula: formula.clone(),
+                            })
+                            .collect();
+
+                    edges.insert(Edges::HYPER(HyperEdge {
+                        source: vert.clone(),
+                        targets,
+                    }));
+                    edges
+                }
+                Phi::EnforceNext { players, formula } => {
                     let moves: Vec<usize> = self
                         .game_structure
                         .move_count(*state)

--- a/src/atl/dependencygraph.rs
+++ b/src/atl/dependencygraph.rs
@@ -496,7 +496,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                     let targets: Vec<ATLVertex> = VarsIterator::new(moves, inv_players)
                         .map(|pmove| ATLVertex::PARTIAL {
                             state: *state,
-                            partial_move: pmove.clone(),
+                            partial_move: pmove,
                             formula: formula.clone(),
                         })
                         .collect();
@@ -566,7 +566,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                     let mut targets: Vec<ATLVertex> = VarsIterator::new(moves, inv_players)
                         .map(|pmove| ATLVertex::PARTIAL {
                             state: *state,
-                            partial_move: pmove.clone(),
+                            partial_move: pmove,
                             formula: formula.clone(),
                         })
                         .collect();

--- a/src/atl/formula.rs
+++ b/src/atl/formula.rs
@@ -45,14 +45,26 @@ pub(crate) enum Phi {
         until: Arc<Phi>,
     },
     /// It must be the case that `formula` is satisfied in some coming step despite what actions `players` choose.
-    #[serde(rename = "despite until")]
+    #[serde(rename = "despite eventually")]
     DespiteEventually {
         players: Vec<Player>,
         formula: Arc<Phi>,
     },
     /// It must be the case that `players` can enforce that `formula` is satisfied in some coming step.
-    #[serde(rename = "despite until")]
+    #[serde(rename = "enforced eventually")]
     EnforcedEventually {
+        players: Vec<Player>,
+        formula: Arc<Phi>,
+    },
+    /// It must be the case that `formula` always is satisfied despite what actions `players` choose.
+    #[serde(rename = "despite always")]
+    DespiteAlways {
+        players: Vec<Player>,
+        formula: Arc<Phi>,
+    },
+    /// It must be the case that `players` can enforce that `formula` always is satisfied.
+    #[serde(rename = "enforced always")]
+    EnforcedAlways {
         players: Vec<Player>,
         formula: Arc<Phi>,
     },
@@ -108,6 +120,18 @@ impl Display for Phi {
             Phi::EnforcedEventually { players, formula } => write!(
                 f,
                 "⟪{}⟫◇{}",
+                players.iter().join_with(",").to_string(),
+                formula
+            ),
+            Phi::DespiteAlways { players, formula } => write!(
+                f,
+                "⟦{}⟧□{}",
+                players.iter().join_with(",").to_string(),
+                formula
+            ),
+            Phi::EnforcedAlways { players, formula } => write!(
+                f,
+                "⟪{}⟫□{}",
                 players.iter().join_with(",").to_string(),
                 formula
             ),

--- a/src/atl/formula.rs
+++ b/src/atl/formula.rs
@@ -6,10 +6,10 @@ use std::sync::Arc;
 /// Alternating-time Temporal Logic formula
 #[derive(Hash, Eq, PartialEq, Clone, Debug, Deserialize, Serialize)]
 pub(crate) enum Phi {
-    /// Always satisfied
+    /// Trivially satisfied
     #[serde(rename = "true")]
     True,
-    /// Never satisfied
+    /// Trivially not satisfied
     #[serde(rename = "false")]
     False,
     /// The current state must have the label/proposition
@@ -62,15 +62,15 @@ pub(crate) enum Phi {
         players: Vec<Player>,
         formula: Arc<Phi>,
     },
-    /// It must be the case that `formula` always is satisfied despite what actions `players` choose.
-    #[serde(rename = "despite always")]
-    DespiteAlways {
+    /// It must be the case that `formula` is continually satisfied despite what actions `players` choose.
+    #[serde(rename = "despite invariant")]
+    DespiteInvariant {
         players: Vec<Player>,
         formula: Arc<Phi>,
     },
-    /// It must be the case that `players` can enforce that `formula` always is satisfied.
-    #[serde(rename = "enforce always")]
-    EnforceAlways {
+    /// It must be the case that `players` can enforce that `formula` is continually satisfied.
+    #[serde(rename = "enforce invariant")]
+    EnforceInvariant {
         players: Vec<Player>,
         formula: Arc<Phi>,
     },
@@ -131,13 +131,13 @@ impl Display for Phi {
                 players.iter().join_with(",").to_string(),
                 formula
             ),
-            Phi::DespiteAlways { players, formula } => write!(
+            Phi::DespiteInvariant { players, formula } => write!(
                 f,
                 "⟦{}⟧□{}",
                 players.iter().join_with(",").to_string(),
                 formula
             ),
-            Phi::EnforceAlways { players, formula } => write!(
+            Phi::EnforceInvariant { players, formula } => write!(
                 f,
                 "⟪{}⟫□{}",
                 players.iter().join_with(",").to_string(),

--- a/src/atl/formula.rs
+++ b/src/atl/formula.rs
@@ -51,8 +51,8 @@ pub(crate) enum Phi {
         formula: Arc<Phi>,
     },
     /// It must be the case that `players` can enforce that `formula` is satisfied in some coming step.
-    #[serde(rename = "enforced eventually")]
-    EnforcedEventually {
+    #[serde(rename = "enforce eventually")]
+    EnforceEventually {
         players: Vec<Player>,
         formula: Arc<Phi>,
     },
@@ -63,8 +63,8 @@ pub(crate) enum Phi {
         formula: Arc<Phi>,
     },
     /// It must be the case that `players` can enforce that `formula` always is satisfied.
-    #[serde(rename = "enforced always")]
-    EnforcedAlways {
+    #[serde(rename = "enforce always")]
+    EnforceAlways {
         players: Vec<Player>,
         formula: Arc<Phi>,
     },
@@ -117,7 +117,7 @@ impl Display for Phi {
                 players.iter().join_with(",").to_string(),
                 formula
             ),
-            Phi::EnforcedEventually { players, formula } => write!(
+            Phi::EnforceEventually { players, formula } => write!(
                 f,
                 "⟪{}⟫◇{}",
                 players.iter().join_with(",").to_string(),
@@ -129,7 +129,7 @@ impl Display for Phi {
                 players.iter().join_with(",").to_string(),
                 formula
             ),
-            Phi::EnforcedAlways { players, formula } => write!(
+            Phi::EnforceAlways { players, formula } => write!(
                 f,
                 "⟪{}⟫□{}",
                 players.iter().join_with(",").to_string(),

--- a/src/atl/formula.rs
+++ b/src/atl/formula.rs
@@ -1,4 +1,5 @@
 use crate::atl::common::{Player, Proposition};
+use joinery::prelude::*;
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
@@ -45,87 +46,62 @@ pub(crate) enum Phi {
 impl Display for Phi {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Phi::Proposition(id) => f.write_fmt(format_args!("'{}'", id)),
-            Phi::Not(formula) => {
-                f.write_str("¬(")?;
-                formula.fmt(f)?;
-                f.write_str(")")
-            }
-            Phi::Or(left, right) => {
-                f.write_str("(")?;
-                left.fmt(f)?;
-                f.write_str(") ∨ (")?;
-                right.fmt(f)?;
-                f.write_str(")")
-            }
-            Phi::DespiteNext { players, formula } => {
-                f.write_str("⟦")?;
-                f.write_str(
-                    players
-                        .iter()
-                        .map(|id| id.to_string())
-                        .collect::<Vec<String>>()
-                        .join(",")
-                        .as_str(),
-                )?;
-                f.write_str("⟧◯[")?;
-                formula.fmt(f)?;
-                f.write_str("]")
-            }
-            Phi::EnforceNext { players, formula } => {
-                f.write_str("⟪")?;
-                f.write_str(
-                    players
-                        .iter()
-                        .map(|id| id.to_string())
-                        .collect::<Vec<String>>()
-                        .join(",")
-                        .as_str(),
-                )?;
-                f.write_str("⟫◯[")?;
-                formula.fmt(f)?;
-                f.write_str("]")
-            }
+            Phi::Proposition(id) => write!(f, "'{}'", id),
+            Phi::Not(formula) => write!(f, "¬({})", formula),
+            Phi::Or(left, right) => write!(f, "({} ∨ {})", left, right),
+            Phi::DespiteNext { players, formula } => write!(
+                f,
+                "⟦{}⟧◯{}",
+                players.iter().join_with(",").to_string(),
+                formula
+            ),
+            Phi::EnforceNext { players, formula } => write!(
+                f,
+                "⟪{}⟫◯{}",
+                players.iter().join_with(",").to_string(),
+                formula
+            ),
             Phi::DespiteUntil {
                 players,
                 pre,
                 until,
-            } => {
-                f.write_str("⟦")?;
-                f.write_str(
-                    players
-                        .iter()
-                        .map(|id| id.to_string())
-                        .collect::<Vec<String>>()
-                        .join(",")
-                        .as_str(),
-                )?;
-                f.write_str("⟧((")?;
-                pre.fmt(f)?;
-                f.write_str(") 𝑼 (")?;
-                until.fmt(f)?;
-                f.write_str("))")
-            }
+            } => write!(
+                f,
+                "⟦{}⟧({} 𝑼 {})",
+                players.iter().join_with(",").to_string(),
+                pre,
+                until
+            ),
             Phi::EnforceUntil {
                 players,
                 pre,
                 until,
-            } => {
-                f.write_str("⟪")?;
-                f.write_str(
-                    players
-                        .iter()
-                        .map(|id| id.to_string())
-                        .collect::<Vec<String>>()
-                        .join(",")
-                        .as_str(),
-                )?;
-                f.write_str("⟫((")?;
-                pre.fmt(f)?;
-                f.write_str(") 𝑼 (")?;
-                until.fmt(f)?;
-                f.write_str("))")
-            }
+            } => write!(
+                f,
+                "⟪{}⟫({} 𝑼 {})",
+                players.iter().join_with(",").to_string(),
+                pre,
+                until
+            ),
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::atl::formula::Phi::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn test_display_01() {
+        let formula = EnforceUntil {
+            players: vec![0, 1],
+            pre: Arc::new(Or {
+                0: Arc::new(Proposition(1)),
+                1: Arc::new(Proposition(2)),
+            }),
+            until: Arc::new(Proposition(0)),
+        };
+        assert_eq!("⟪0,1⟫(('1' ∨ '2') 𝑼 '0')", format!("{}", formula));
     }
 }

--- a/src/atl/formula.rs
+++ b/src/atl/formula.rs
@@ -14,9 +14,15 @@ pub(crate) enum Phi {
     /// It must be the case that either formula is satisfied
     #[serde(rename = "or")]
     Or(Arc<Phi>, Arc<Phi>),
+    /// It must be the case that `formula` is satisfied in the next step despite what actions `players` choose.
+    #[serde(rename = "despite next")]
+    DespiteNext {
+        players: Vec<Player>,
+        formula: Arc<Phi>,
+    },
     /// It must be the case that players can enforce that `formula` is satisfied in the next step
-    #[serde(rename = "next")]
-    Next {
+    #[serde(rename = "enforce next")]
+    EnforceNext {
         players: Vec<Player>,
         formula: Arc<Phi>,
     },
@@ -52,7 +58,21 @@ impl Display for Phi {
                 right.fmt(f)?;
                 f.write_str(")")
             }
-            Phi::Next { players, formula } => {
+            Phi::DespiteNext { players, formula } => {
+                f.write_str("⟦")?;
+                f.write_str(
+                    players
+                        .iter()
+                        .map(|id| id.to_string())
+                        .collect::<Vec<String>>()
+                        .join(",")
+                        .as_str(),
+                )?;
+                f.write_str("⟧◯[")?;
+                formula.fmt(f)?;
+                f.write_str("]")
+            }
+            Phi::EnforceNext { players, formula } => {
                 f.write_str("⟪")?;
                 f.write_str(
                     players

--- a/src/atl/formula.rs
+++ b/src/atl/formula.rs
@@ -37,12 +37,24 @@ pub(crate) enum Phi {
         pre: Arc<Phi>,
         until: Arc<Phi>,
     },
-    /// It must be that `players` can enforce that `pre` is satisfied until `until` is satisfied
+    /// It must be the case that `players` can enforce that `pre` is satisfied until `until` is satisfied
     #[serde(rename = "enforce until")]
     EnforceUntil {
         players: Vec<Player>,
         pre: Arc<Phi>,
         until: Arc<Phi>,
+    },
+    /// It must be the case that `formula` is satisfied in some coming step despite what actions `players` choose.
+    #[serde(rename = "despite until")]
+    DespiteEventually {
+        players: Vec<Player>,
+        formula: Arc<Phi>,
+    },
+    /// It must be the case that `players` can enforce that `formula` is satisfied in some coming step.
+    #[serde(rename = "despite until")]
+    EnforcedEventually {
+        players: Vec<Player>,
+        formula: Arc<Phi>,
     },
 }
 
@@ -86,6 +98,18 @@ impl Display for Phi {
                 players.iter().join_with(",").to_string(),
                 pre,
                 until
+            ),
+            Phi::DespiteEventually { players, formula } => write!(
+                f,
+                "⟦{}⟧◇{}",
+                players.iter().join_with(",").to_string(),
+                formula
+            ),
+            Phi::EnforcedEventually { players, formula } => write!(
+                f,
+                "⟪{}⟫◇{}",
+                players.iter().join_with(",").to_string(),
+                formula
             ),
         }
     }

--- a/src/atl/formula.rs
+++ b/src/atl/formula.rs
@@ -4,8 +4,14 @@ use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
 /// Alternating-time Temporal Logic formula
-#[derive(Hash, Eq, PartialEq, Clone, Debug, Deserialize)]
+#[derive(Hash, Eq, PartialEq, Clone, Debug, Deserialize, Serialize)]
 pub(crate) enum Phi {
+    /// Always satisfied
+    #[serde(rename = "true")]
+    True,
+    /// Never satisfied
+    #[serde(rename = "false")]
+    False,
     /// The current state must have the label/proposition
     #[serde(rename = "proposition")]
     Proposition(Proposition),
@@ -73,6 +79,8 @@ pub(crate) enum Phi {
 impl Display for Phi {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
+            Phi::True => write!(f, "true"),
+            Phi::False => write!(f, "false"),
             Phi::Proposition(id) => write!(f, "'{}'", id),
             Phi::Not(formula) => write!(f, "¬({})", formula),
             Phi::Or(left, right) => write!(f, "({} ∨ {})", left, right),
@@ -150,10 +158,10 @@ mod test {
             players: vec![0, 1],
             pre: Arc::new(Or {
                 0: Arc::new(Proposition(1)),
-                1: Arc::new(Proposition(2)),
+                1: Arc::new(Not(Arc::new(Proposition(2)))),
             }),
-            until: Arc::new(Proposition(0)),
+            until: Arc::new(False),
         };
-        assert_eq!("⟪0,1⟫(('1' ∨ '2') 𝑼 '0')", format!("{}", formula));
+        assert_eq!("⟪0,1⟫(('1' ∨ ¬('2')) 𝑼 false)", format!("{}", formula));
     }
 }

--- a/src/atl/formula.rs
+++ b/src/atl/formula.rs
@@ -15,6 +15,9 @@ pub(crate) enum Phi {
     /// It must be the case that either formula is satisfied
     #[serde(rename = "or")]
     Or(Arc<Phi>, Arc<Phi>),
+    /// It must be the case that either formula is satisfied
+    #[serde(rename = "and")]
+    And(Arc<Phi>, Arc<Phi>),
     /// It must be the case that `formula` is satisfied in the next step despite what actions `players` choose.
     #[serde(rename = "despite next")]
     DespiteNext {
@@ -49,6 +52,7 @@ impl Display for Phi {
             Phi::Proposition(id) => write!(f, "'{}'", id),
             Phi::Not(formula) => write!(f, "¬({})", formula),
             Phi::Or(left, right) => write!(f, "({} ∨ {})", left, right),
+            Phi::And(left, right) => write!(f, "({} ∧ {})", left, right),
             Phi::DespiteNext { players, formula } => write!(
                 f,
                 "⟦{}⟧◯{}",

--- a/src/atl/gamestructure/eager.rs
+++ b/src/atl/gamestructure/eager.rs
@@ -7,18 +7,18 @@ use crate::atl::gamestructure::GameStructure;
 #[derive(Clone, Debug, Deserialize)]
 pub struct EagerGameStructure {
     /// K, number of players
-    pub player_count: u32,
+    pub player_count: usize,
     /// Maps states to Vec of atomic proposition, aka the labeling function
     pub labeling: Vec<HashSet<Proposition>>,
     /// Maps states, then players recursively
     pub transitions: Vec<DynVec>,
     /// available moves for a player in a given state
-    pub moves: Vec<Vec<u32>>,
+    pub moves: Vec<Vec<usize>>,
 }
 
 impl EagerGameStructure {
     /// Returns the number of moves `player` can take when the game is in `state`.
-    pub fn available_moves(&self, state: State, player: Player) -> u32 {
+    pub fn available_moves(&self, state: State, player: Player) -> usize {
         *self
             .moves
             .get(state)
@@ -34,7 +34,7 @@ impl EagerGameStructure {
 }
 
 impl GameStructure for EagerGameStructure {
-    fn max_player(&self) -> u32 {
+    fn max_player(&self) -> usize {
         self.player_count
     }
 
@@ -55,7 +55,7 @@ impl GameStructure for EagerGameStructure {
         )
     }
 
-    fn move_count(&self, state: State) -> Vec<u32> {
+    fn move_count(&self, state: State) -> Vec<usize> {
         self.moves
             .get(state)
             .unwrap_or_else(|| panic!("Requested move for non-existent state {}", state))

--- a/src/atl/gamestructure/mod.rs
+++ b/src/atl/gamestructure/mod.rs
@@ -8,12 +8,12 @@ use crate::atl::common::{Proposition, State};
 mod eager;
 
 pub trait GameStructure {
-    fn max_player(&self) -> u32;
+    fn max_player(&self) -> usize;
 
     fn labels(&self, state: State) -> HashSet<Proposition>;
 
     fn transitions(&self, state: State, choices: Vec<usize>) -> State;
 
     /// Returns the number of moves each player can take when the game is in `state`.
-    fn move_count(&self, state: State) -> Vec<u32>;
+    fn move_count(&self, state: State) -> Vec<usize>;
 }

--- a/src/lcgs/ir/intermediate.rs
+++ b/src/lcgs/ir/intermediate.rs
@@ -362,8 +362,8 @@ fn check_and_optimize_decls(symbols: &SymbolTable) -> Result<(), ()> {
 pub struct State(pub HashMap<SymbolIdentifier, i32>);
 
 impl GameStructure for IntermediateLCGS {
-    fn max_player(&self) -> u32 {
-        self.players.len() as u32
+    fn max_player(&self) -> usize {
+        self.players.len()
     }
 
     /// Returns the set of labels/propositions available in the given state.
@@ -416,12 +416,12 @@ impl GameStructure for IntermediateLCGS {
     }
 
     /// Returns the number of moves available to each player in the given state.
-    fn move_count(&self, state: usize) -> Vec<u32> {
+    fn move_count(&self, state: usize) -> Vec<usize> {
         let state = self.state_from_index(state);
         self.players
             .iter()
             .enumerate()
-            .map(|(i, _player)| self.available_moves(&state, i).len() as u32)
+            .map(|(i, _player)| self.available_moves(&state, i).len())
             .collect()
     }
 }


### PR DESCRIPTION
This PR adds the following terms to ATL formulas:
* True
* False
* And
* DespiteNext (and renames Next to EnforcedNext)
* EnforceEventually
* DespiteEventually
* EnforceInvariant
* DespiteInvariant

It should be easy to convince yourself that the edges and successor configurations are correct (It's just proving it, that is hard).

There are also some clean up like improving comments and replacing some u32 with usize.