### PR TITLE
Remove [ignored] from working tests

### DIFF
--- a/src/edg.rs
+++ b/src/edg.rs
@@ -1134,7 +1134,6 @@ mod test {
     }
 
     #[test]
-    //#[ignore]
     fn test_small_dg_all_true_except_for_c() {
         warn!("foo bar");
         #[derive(Hash, Clone, Eq, PartialEq, Debug)]
@@ -1232,7 +1231,6 @@ mod test {
     }
 
     #[test]
-    //#[ignore]
     fn test_small_dg_all_false_except_for_d() {
         #[derive(Hash, Clone, Eq, PartialEq, Debug)]
         enum ExampleEDGVertices {
@@ -1328,7 +1326,6 @@ mod test {
     }
 
     #[test]
-    //#[ignore]
     fn test_a_node_with_no_succsessors() {
         #[derive(Hash, Clone, Eq, PartialEq, Debug)]
         enum ExampleEDGVertices {
@@ -1366,7 +1363,6 @@ mod test {
     }
 
     #[test]
-    //#[ignore]
     fn test_termination_condtion() {
         #[derive(Hash, Clone, Eq, PartialEq, Debug)]
         enum ExampleEDGVertices {
@@ -1421,7 +1417,6 @@ mod test {
     }
 
     #[test]
-    //#[ignore]
     fn test_loop_di_loops() {
         #[derive(Hash, Clone, Eq, PartialEq, Debug)]
         enum ExampleEDGVertices {
@@ -1516,7 +1511,6 @@ mod test {
     }
 
     #[test]
-    #[ignore]
     fn test_negation_edges() {
         #[derive(Hash, Clone, Eq, PartialEq, Debug)]
         enum ExampleEDGVertices {

--- a/src/lcgs/ir/symbol_checker.rs
+++ b/src/lcgs/ir/symbol_checker.rs
@@ -23,9 +23,10 @@ impl CheckMode {
             CheckMode::LabelOrTransition => {
                 matches!(decl_kind, DeclKind::Const(_) | DeclKind::StateVar(_))
             }
-            CheckMode::StateVarUpdate => {
-                matches!(decl_kind, DeclKind::Const(_) | DeclKind::StateVar(_) | DeclKind::Transition(_))
-            }
+            CheckMode::StateVarUpdate => matches!(
+                decl_kind,
+                DeclKind::Const(_) | DeclKind::StateVar(_) | DeclKind::Transition(_)
+            ),
         }
     }
 }


### PR DESCRIPTION
All of our tests now succeeds, so let's remove the [ignore] annotation so we can keep it that way.