### PR TITLE
Ignore all Cargo.lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 target
 /.idea
 model-checker.log
-/atl-checker/Cargo.lock
+Cargo.lock


### PR DESCRIPTION
#115 broke the gitignore directive for `Cargo.lock` files