### PR TITLE
Update tracing-subscriber dependency

### DIFF
--- a/atl-checker/Cargo.toml
+++ b/atl-checker/Cargo.toml
@@ -33,7 +33,7 @@ clap = "2.33.3"
 serde = { version = "1.0.117", features = ["derive", "rc"] }
 serde_json = "1.0.59"
 tracing = "0.1"
-tracing-subscriber = "0.2"
+tracing-subscriber = "0.2.17"
 lazy_static = "1.4.0"
 joinery = "2.0.0"
 git-version = "0.3.4"


### PR DESCRIPTION
This get rid of the current test compile error