### PR TITLE
[P8-86] Support for search strategies

### DIFF
--- a/atl-checker/src/edg.rs
+++ b/atl-checker/src/edg.rs
@@ -9,6 +9,8 @@ use crate::com::{Broker, BrokerManager, ChannelBroker};
 use crate::common::{
     Edges, HyperEdge, Message, MsgToken, NegationEdge, Token, VertexAssignment, WorkerId,
 };
+use crate::search_strategy::bfs::BreadthFirstSearch;
+use crate::search_strategy::SearchStrategy;
 use std::cmp::max;
 use std::thread::sleep;
 use std::time::Duration;
@@ -43,6 +45,7 @@ pub fn distributed_certain_zero<
             v0.clone(),
             brokers.pop().unwrap(),
             edg.clone(),
+            BreadthFirstSearch::new(),
         );
         thread::spawn(move || {
             trace!("worker thread start");
@@ -58,7 +61,8 @@ pub fn distributed_certain_zero<
 }
 
 #[derive(Debug)]
-struct Worker<B: Broker<V> + Debug, G: ExtendedDependencyGraph<V>, V: Vertex> {
+struct Worker<B: Broker<V> + Debug, G: ExtendedDependencyGraph<V>, V: Vertex, S: SearchStrategy<V>>
+{
     id: WorkerId,
     /// Number of workers working on solving the query. This is used as part of the static allocation scheme, see `crate::Worker::vertex_owner`.
     worker_count: u64,
@@ -76,9 +80,9 @@ struct Worker<B: Broker<V> + Debug, G: ExtendedDependencyGraph<V>, V: Vertex> {
     /// Example: If there exists a path from v0 to a vertex, which contains two negation edges, then depth will be two (or more if there is a path with more negation edges).
     depth: HashMap<V, u32>,
     msg_queue: VecDeque<Message<V>>,
-    hyper_queue: VecDeque<HyperEdge<V>>,
-    negation_queue: VecDeque<NegationEdge<V>>,
     unsafe_neg_edges: Vec<Vec<NegationEdge<V>>>,
+    /// Search strategy. Defines in which order edges are processed
+    strategy: S,
     /// Used to communicate with other workers
     broker: B,
     /// The logic of handling which edges have been deleted from a vertex is delegated to Worker instead of having to be duplicated in every implementation of ExtendedDependencyGraph.
@@ -97,8 +101,12 @@ struct Worker<B: Broker<V> + Debug, G: ExtendedDependencyGraph<V>, V: Vertex> {
     only_unsafe_left: bool,
 }
 
-impl<B: Broker<V> + Debug, G: ExtendedDependencyGraph<V> + Send + Sync + Debug, V: Vertex>
-    Worker<B, G, V>
+impl<
+        B: Broker<V> + Debug,
+        G: ExtendedDependencyGraph<V> + Send + Sync + Debug,
+        V: Vertex,
+        S: SearchStrategy<V>,
+    > Worker<B, G, V, S>
 {
     /// Determines which worker instance is responsible for computing the value of the vertex.
     /// Vertices are allocated to workers using a static allocation scheme. Dynamic addition and removal of workers isn't supported with this method.
@@ -117,7 +125,7 @@ impl<B: Broker<V> + Debug, G: ExtendedDependencyGraph<V> + Send + Sync + Debug, 
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn new(id: WorkerId, worker_count: u64, v0: V, broker: B, edg: G) -> Self {
+    pub fn new(id: WorkerId, worker_count: u64, v0: V, broker: B, edg: G, strategy: S) -> Self {
         trace!(
             worker_id = id,
             worker_count,
@@ -134,9 +142,8 @@ impl<B: Broker<V> + Debug, G: ExtendedDependencyGraph<V> + Send + Sync + Debug, 
             depends: HashMap::<V, HashSet<Edges<V>>>::new(),
             interests: HashMap::<V, HashSet<WorkerId>>::new(),
             msg_queue: VecDeque::new(),
-            hyper_queue: VecDeque::new(),
-            negation_queue: VecDeque::new(),
             unsafe_neg_edges: Vec::<Vec<NegationEdge<V>>>::new(),
+            strategy,
             depth: HashMap::<V, u32>::new(),
             broker,
             successors: HashMap::<V, HashSet<Edges<V>>>::new(),
@@ -354,23 +361,15 @@ impl<B: Broker<V> + Debug, G: ExtendedDependencyGraph<V> + Send + Sync + Debug, 
                 _ => unreachable!(),
             }
             return true;
-        } else if let Some(edge) = self.hyper_queue.pop_front() {
-            let _guard = span!(
-                Level::TRACE,
-                "worker receive hyper-edge",
-                worker_id = self.id,
-                ?edge,
-            );
-            self.process_hyper_edge(edge);
-            return true;
-        } else if let Some(edge) = self.negation_queue.pop_front() {
-            let _guard = span!(
-                Level::TRACE,
-                "worker receive negation-edge",
-                worker_id = self.id,
-                ?edge,
-            );
-            self.process_negation_edge(edge);
+        } else if let Some(edge) = self.strategy.next() {
+            match edge {
+                Edges::HYPER(e) => {
+                    self.process_hyper_edge(e);
+                }
+                Edges::NEGATION(e) => {
+                    self.process_negation_edge(e);
+                }
+            }
             return true;
         }
         // No tasks
@@ -400,10 +399,8 @@ impl<B: Broker<V> + Debug, G: ExtendedDependencyGraph<V> + Send + Sync + Debug, 
 
         if let Some(edges) = self.unsafe_neg_edges.pop() {
             // Queue all edges in the negation channel that have the given depth
-            for edge in edges {
-                trace!(?edge, "releasing negation edge");
-                self.negation_queue.push_back(edge);
-            }
+            trace!("releasing negation edges");
+            self.strategy.queue_released_edges(edges);
         }
     }
 
@@ -445,12 +442,7 @@ impl<B: Broker<V> + Debug, G: ExtendedDependencyGraph<V> + Send + Sync + Debug, 
             } else {
                 // Line 5
                 // Queue the new edges
-                for edge in &successors {
-                    match edge {
-                        Edges::HYPER(edge) => self.hyper_queue.push_back(edge.clone()),
-                        Edges::NEGATION(edge) => self.negation_queue.push_back(edge.clone()),
-                    }
-                }
+                self.strategy.queue_new_edges(successors);
             }
         } else {
             // Line 7
@@ -701,10 +693,7 @@ impl<B: Broker<V> + Debug, G: ExtendedDependencyGraph<V> + Send + Sync + Debug, 
             if let Some(depends) = self.depends.get(&vertex) {
                 for edge in depends.clone() {
                     trace!(?edge, "requeueing edge because target got assignment");
-                    match edge {
-                        Edges::HYPER(edge) => self.hyper_queue.push_back(edge.clone()),
-                        Edges::NEGATION(edge) => self.negation_queue.push_back(edge.clone()),
-                    }
+                    self.strategy.queue_back_propagation(edge)
                 }
             }
         }

--- a/atl-checker/src/edg.rs
+++ b/atl-checker/src/edg.rs
@@ -9,7 +9,6 @@ use crate::com::{Broker, BrokerManager, ChannelBroker};
 use crate::common::{
     Edges, HyperEdge, Message, MsgToken, NegationEdge, Token, VertexAssignment, WorkerId,
 };
-use crate::search_strategy::bfs::BreadthFirstSearch;
 use crate::search_strategy::{SearchStrategy, SearchStrategyBuilder};
 use std::cmp::max;
 use std::thread::sleep;

--- a/atl-checker/src/lib.rs
+++ b/atl-checker/src/lib.rs
@@ -14,3 +14,4 @@ mod common;
 pub mod edg;
 pub mod lcgs;
 mod printer;
+mod search_strategy;

--- a/atl-checker/src/main.rs
+++ b/atl-checker/src/main.rs
@@ -31,6 +31,7 @@ use crate::lcgs::ir::symbol_table::Owner;
 use crate::lcgs::parse::parse_lcgs;
 #[cfg(feature = "graph-printer")]
 use crate::printer::print_graph;
+use crate::search_strategy::bfs::BreadthFirstSearchBuilder;
 
 #[macro_use]
 mod simple_edg;
@@ -130,7 +131,8 @@ fn main_inner() -> Result<(), String> {
             where
                 G: GameStructure + Send + Sync + Clone + Debug + 'static,
             {
-                let result = distributed_certain_zero(graph, v0, threads);
+                let result =
+                    distributed_certain_zero(graph, v0, threads, BreadthFirstSearchBuilder);
                 println!("Result: {}", result);
             }
 

--- a/atl-checker/src/main.rs
+++ b/atl-checker/src/main.rs
@@ -41,6 +41,7 @@ mod edg;
 mod lcgs;
 #[cfg(feature = "graph-printer")]
 mod printer;
+mod search_strategy;
 
 const PKG_NAME: &str = env!("CARGO_PKG_NAME");
 const AUTHORS: &str = env!("CARGO_PKG_AUTHORS");

--- a/atl-checker/src/search_strategy/bfs.rs
+++ b/atl-checker/src/search_strategy/bfs.rs
@@ -1,0 +1,22 @@
+use crate::common::{Edges, HyperEdge, NegationEdge};
+use crate::edg::Vertex;
+use crate::search_strategy::SearchStrategy;
+use std::collections::{HashSet, VecDeque};
+
+/// Breadth-first search strategy traverses vertices close to the root first, using a FIFO
+/// (first in, first out) data structure.
+pub struct BreadthFirstSearch<V> {
+    queue: VecDeque<Edges<V>>,
+}
+
+impl<V: Vertex> SearchStrategy<V> for BreadthFirstSearch<V> {
+    fn next(&mut self) -> Option<Edges<V>> {
+        self.queue.pop_front()
+    }
+
+    fn queue_new_edges(&mut self, edges: HashSet<Edges<V>>) {
+        for edge in edges {
+            self.queue.push_back(edge);
+        }
+    }
+}

--- a/atl-checker/src/search_strategy/bfs.rs
+++ b/atl-checker/src/search_strategy/bfs.rs
@@ -29,6 +29,7 @@ impl<V: Vertex> SearchStrategy<V> for BreadthFirstSearch<V> {
     }
 }
 
+/// A SearchStrategyBuilder for building the BreadthFirstSearch strategy.
 pub struct BreadthFirstSearchBuilder;
 
 impl<V: Vertex> SearchStrategyBuilder<V, BreadthFirstSearch<V>> for BreadthFirstSearchBuilder {

--- a/atl-checker/src/search_strategy/bfs.rs
+++ b/atl-checker/src/search_strategy/bfs.rs
@@ -5,8 +5,16 @@ use std::collections::{HashSet, VecDeque};
 
 /// Breadth-first search strategy traverses vertices close to the root first, using a FIFO
 /// (first in, first out) data structure.
-pub struct BreadthFirstSearch<V> {
+pub struct BreadthFirstSearch<V: Vertex> {
     queue: VecDeque<Edges<V>>,
+}
+
+impl<V: Vertex> BreadthFirstSearch<V> {
+    pub fn new() -> BreadthFirstSearch<V> {
+        BreadthFirstSearch {
+            queue: VecDeque::new(),
+        }
+    }
 }
 
 impl<V: Vertex> SearchStrategy<V> for BreadthFirstSearch<V> {

--- a/atl-checker/src/search_strategy/bfs.rs
+++ b/atl-checker/src/search_strategy/bfs.rs
@@ -1,6 +1,6 @@
-use crate::common::{Edges, HyperEdge, NegationEdge};
+use crate::common::Edges;
 use crate::edg::Vertex;
-use crate::search_strategy::SearchStrategy;
+use crate::search_strategy::{SearchStrategy, SearchStrategyBuilder};
 use std::collections::{HashSet, VecDeque};
 
 /// Breadth-first search strategy traverses vertices close to the root first, using a FIFO
@@ -26,5 +26,13 @@ impl<V: Vertex> SearchStrategy<V> for BreadthFirstSearch<V> {
         for edge in edges {
             self.queue.push_back(edge);
         }
+    }
+}
+
+pub struct BreadthFirstSearchBuilder;
+
+impl<V: Vertex> SearchStrategyBuilder<V, BreadthFirstSearch<V>> for BreadthFirstSearchBuilder {
+    fn build(&self) -> BreadthFirstSearch<V> {
+        BreadthFirstSearch::new()
     }
 }

--- a/atl-checker/src/search_strategy/mod.rs
+++ b/atl-checker/src/search_strategy/mod.rs
@@ -4,6 +4,10 @@ use crate::common::{Edges, NegationEdge};
 use crate::edg::Vertex;
 use std::collections::HashSet;
 
+/// A SearchStrategy defines in which order safe edges of an EDG is processed first in the
+/// certain zero algorithm.
+/// The trait supports multiple functions to queue edges. This allows us to make search strategies
+/// that prioritises certain reasons queueing differently.
 pub trait SearchStrategy<V: Vertex> {
     /// Returns the next edge to be processed, or none if there are no safe edges to process.
     fn next(&mut self) -> Option<Edges<V>>;
@@ -25,6 +29,9 @@ pub trait SearchStrategy<V: Vertex> {
     }
 }
 
+/// A SearchStrategyBuilder is able to create an instance of a SearchStrategy.
+/// This trait allows us to create a SearchStrategy instance for each worker in the certain zero
+/// algorithm, based on the settings given by the user.
 pub trait SearchStrategyBuilder<V: Vertex, S: SearchStrategy<V>> {
     fn build(&self) -> S;
 }

--- a/atl-checker/src/search_strategy/mod.rs
+++ b/atl-checker/src/search_strategy/mod.rs
@@ -1,0 +1,24 @@
+mod bfs;
+
+use crate::common::{Edges, NegationEdge};
+use crate::edg::Vertex;
+use std::collections::HashSet;
+
+pub trait SearchStrategy<V: Vertex> {
+    /// Returns the next edge to be processed, or none if there are no safe edges to process.
+    fn next(&mut self) -> Option<Edges<V>>;
+
+    /// Queue a set of safe edges with the heuristic
+    fn queue_new_edges(&mut self, edges: HashSet<Edges<V>>);
+
+    /// Queue a set of previously unsafe negation edges
+    fn queue_released_edges(&mut self, edges: Vec<NegationEdge<V>>) {
+        let mut edges = edges;
+        self.queue_new_edges(edges.drain(..).map(|edge| Edges::NEGATION(edge)).collect())
+    }
+
+    /// Requeue an edge because one of its targets was assigned a certain value
+    fn queue_back_propagation(&mut self, edge: Edges<V>) {
+        self.queue_new_edges(Some(edge).iter().collect())
+    }
+}

--- a/atl-checker/src/search_strategy/mod.rs
+++ b/atl-checker/src/search_strategy/mod.rs
@@ -24,3 +24,7 @@ pub trait SearchStrategy<V: Vertex> {
         self.queue_new_edges(set)
     }
 }
+
+pub trait SearchStrategyBuilder<V: Vertex, S: SearchStrategy<V>> {
+    fn build(&self) -> S;
+}

--- a/atl-checker/src/search_strategy/mod.rs
+++ b/atl-checker/src/search_strategy/mod.rs
@@ -1,4 +1,4 @@
-mod bfs;
+pub mod bfs;
 
 use crate::common::{Edges, NegationEdge};
 use crate::edg::Vertex;
@@ -19,6 +19,8 @@ pub trait SearchStrategy<V: Vertex> {
 
     /// Requeue an edge because one of its targets was assigned a certain value
     fn queue_back_propagation(&mut self, edge: Edges<V>) {
-        self.queue_new_edges(Some(edge).iter().collect())
+        let mut set = HashSet::new();
+        set.insert(edge);
+        self.queue_new_edges(set)
     }
 }

--- a/atl-checker/src/search_strategy/mod.rs
+++ b/atl-checker/src/search_strategy/mod.rs
@@ -14,7 +14,7 @@ pub trait SearchStrategy<V: Vertex> {
     /// Queue a set of previously unsafe negation edges
     fn queue_released_edges(&mut self, edges: Vec<NegationEdge<V>>) {
         let mut edges = edges;
-        self.queue_new_edges(edges.drain(..).map(|edge| Edges::NEGATION(edge)).collect())
+        self.queue_new_edges(edges.drain(..).map(Edges::NEGATION).collect())
     }
 
     /// Requeue an edge because one of its targets was assigned a certain value

--- a/atl-checker/src/simple_edg.rs
+++ b/atl-checker/src/simple_edg.rs
@@ -151,7 +151,7 @@ macro_rules! edg_assert {
     // With custom names and worker count
     ( [$edg_name:ident, $vertex_name:ident] $v:ident, $assign:ident, $wc:expr ) => {
         assert_eq!(
-            distributed_certain_zero($edg_name, $vertex_name::$v, $wc),
+            distributed_certain_zero($edg_name, $vertex_name::$v, $wc, BreadthFirstSearchBuilder),
             crate::common::VertexAssignment::$assign,
             "Vertex {}",
             stringify!($v)


### PR DESCRIPTION
This PR adds supports for search strategies for the distributed certain zero. The search strategy manage in which order safe hyper-edges and negation edges are processed. Currently, there is only one search strategy: breadth-first search.

Depends on #129 for no reason