### PR TITLE
[P8-87] Make succ return Vec for more structure

### DIFF
--- a/atl-checker/src/atl/dependencygraph.rs
+++ b/atl-checker/src/atl/dependencygraph.rs
@@ -311,11 +311,11 @@ impl<G: GameStructure> ATLDependencyGraph<G> {
 }
 
 impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph<G> {
+    /// Produce the edges of the given vertex
+    /// Where possible, the smallest edge will be the first in the produced vector,
+    /// and similarly, the smallest target will be the first in the edges' vector of targets.
+    /// This is mostly relevant for the Until formulae
     fn succ(&self, vert: &ATLVertex) -> Vec<Edge<ATLVertex>> {
-        // Produce the edges of the given vertex
-        // Where possible, the smallest edge will be the first in the produced vector,
-        // and similarly, the smallest target will be the first in the edges' vector of targets.
-        // This is mostly relevant for the Until formulae
         match vert {
             ATLVertex::FULL { state, formula } => match formula.as_ref() {
                 Phi::True => {
@@ -453,6 +453,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                     vec![
                         // `until`-formula branch
                         // "Is the `until` formula satisfied now?"
+                        // This must be the first edge
                         Edge::HYPER(HyperEdge {
                             source: vert.clone(),
                             pmove: None,
@@ -477,6 +478,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                     let mut edges = vec![
                         // `until`-formula branch
                         // "Is the `until` formula satisfied now?"
+                        // This must be the first edge
                         Edge::HYPER(HyperEdge {
                             source: vert.clone(),
                             pmove: None,
@@ -539,6 +541,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                     vec![
                         // sub-formula target
                         // "Is the sub formula satisfied in current state?"
+                        // This must be the first edge
                         Edge::HYPER(HyperEdge {
                             source: vert.clone(),
                             pmove: None,
@@ -561,6 +564,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                     let mut edges = vec![
                         // sub-formula target
                         // "Is the sub formula satisfied in current state?"
+                        // This must be the first edge
                         Edge::HYPER(HyperEdge {
                             source: vert.clone(),
                             pmove: None,

--- a/atl-checker/src/atl/dependencygraph.rs
+++ b/atl-checker/src/atl/dependencygraph.rs
@@ -1,4 +1,4 @@
-use crate::common::{Edges, HyperEdge, NegationEdge};
+use crate::common::{Edge, HyperEdge, NegationEdge};
 use crate::edg::{ExtendedDependencyGraph, Vertex};
 use std::collections::hash_map::RandomState;
 use std::collections::HashSet;
@@ -8,6 +8,7 @@ use crate::atl::common::{Player, State};
 use crate::atl::formula::Phi;
 use crate::atl::gamestructure::GameStructure;
 use std::fmt::{Display, Formatter};
+use std::iter::Once;
 
 #[derive(Clone, Debug)]
 pub struct ATLDependencyGraph<G: GameStructure> {
@@ -169,13 +170,13 @@ impl<'a> Iterator for PartialMoveIterator<'a> {
     }
 }
 
-pub struct VarsIterator {
+pub struct PmovesIterator {
     moves: Vec<usize>,
     position: PartialMove,
     completed: bool,
 }
 
-impl VarsIterator {
+impl PmovesIterator {
     /// Iterates over all partial moves variants that results from a number of players
     /// making a combination of specific choices.
     ///
@@ -202,7 +203,7 @@ impl VarsIterator {
     }
 }
 
-impl Iterator for VarsIterator {
+impl Iterator for PmovesIterator {
     type Item = PartialMove;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -310,97 +311,86 @@ impl<G: GameStructure> ATLDependencyGraph<G> {
 }
 
 impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph<G> {
-    fn succ(&self, vert: &ATLVertex) -> HashSet<Edges<ATLVertex>, RandomState> {
+    fn succ(&self, vert: &ATLVertex) -> Vec<Edge<ATLVertex>> {
+        // Produce the edges of the given vertex
+        // Where possible, the smallest edge will be the first in the produced vector,
+        // and similarly, the smallest target will be the first in the edges' vector of targets.
+        // This is mostly relevant for the Until formulae
         match vert {
             ATLVertex::FULL { state, formula } => match formula.as_ref() {
                 Phi::True => {
-                    let mut edges = HashSet::new();
-
-                    // Empty hyper edge
-                    edges.insert(Edges::HYPER(HyperEdge {
+                    // Hyper edge with no targets
+                    vec![Edge::HYPER(HyperEdge {
                         source: vert.clone(),
+                        pmove: None,
                         targets: vec![],
-                    }));
-
-                    edges
+                    })]
                 }
                 Phi::False => {
                     // No edges
-                    HashSet::new()
+                    vec![]
                 }
                 Phi::Proposition(prop) => {
                     let props = self.game_structure.labels(vert.state());
                     if props.contains(prop) {
-                        let mut edges: HashSet<Edges<ATLVertex>> = HashSet::new();
-                        edges.insert(Edges::HYPER(HyperEdge {
+                        vec![Edge::HYPER(HyperEdge {
                             source: vert.clone(),
+                            pmove: None,
                             targets: vec![],
-                        }));
-                        edges
+                        })]
                     } else {
-                        HashSet::new()
+                        vec![]
                     }
                 }
                 Phi::Not(phi) => {
-                    let mut edges: HashSet<Edges<ATLVertex>> = HashSet::new();
-
-                    edges.insert(Edges::NEGATION(NegationEdge {
+                    vec![Edge::NEGATION(NegationEdge {
                         source: vert.clone(),
                         target: ATLVertex::FULL {
                             state: *state,
                             formula: phi.clone(),
                         },
-                    }));
-
-                    edges
+                    })]
                 }
                 Phi::Or(left, right) => {
-                    let mut edges = HashSet::new();
-
-                    edges.insert(Edges::HYPER(HyperEdge {
-                        source: vert.clone(),
-                        targets: vec![ATLVertex::FULL {
-                            state: *state,
-                            formula: left.clone(),
-                        }],
-                    }));
-
-                    edges.insert(Edges::HYPER(HyperEdge {
-                        source: vert.clone(),
-                        targets: vec![ATLVertex::FULL {
-                            state: *state,
-                            formula: right.clone(),
-                        }],
-                    }));
-
-                    edges
+                    vec![
+                        Edge::HYPER(HyperEdge {
+                            source: vert.clone(),
+                            pmove: None,
+                            targets: vec![ATLVertex::FULL {
+                                state: *state,
+                                formula: left.clone(),
+                            }],
+                        }),
+                        Edge::HYPER(HyperEdge {
+                            source: vert.clone(),
+                            pmove: None,
+                            targets: vec![ATLVertex::FULL {
+                                state: *state,
+                                formula: right.clone(),
+                            }],
+                        }),
+                    ]
                 }
                 Phi::And(left, right) => {
-                    let mut edges = HashSet::new();
-                    let mut targets = vec![];
-
-                    targets.push(ATLVertex::FULL {
-                        state: *state,
-                        formula: left.clone(),
-                    });
-                    targets.push(ATLVertex::FULL {
-                        state: *state,
-                        formula: right.clone(),
-                    });
-
-                    edges.insert(Edges::HYPER(HyperEdge {
+                    vec![Edge::HYPER(HyperEdge {
                         source: vert.clone(),
-                        targets,
-                    }));
-
-                    edges
+                        pmove: None,
+                        targets: vec![
+                            ATLVertex::FULL {
+                                state: *state,
+                                formula: left.clone(),
+                            },
+                            ATLVertex::FULL {
+                                state: *state,
+                                formula: right.clone(),
+                            },
+                        ],
+                    })]
                 }
                 Phi::DespiteNext { players, formula } => {
-                    let mut edges = HashSet::new();
-
                     let moves = self.game_structure.move_count(*state);
                     let targets: Vec<ATLVertex> =
-                        VarsIterator::new(moves, players.iter().copied().collect())
+                        PmovesIterator::new(moves, players.iter().copied().collect())
                             .map(|pmove| ATLVertex::PARTIAL {
                                 state: *state,
                                 partial_move: pmove,
@@ -408,15 +398,15 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                             })
                             .collect();
 
-                    edges.insert(Edges::HYPER(HyperEdge {
+                    vec![Edge::HYPER(HyperEdge {
                         source: vert.clone(),
+                        pmove: None,
                         targets,
-                    }));
-                    edges
+                    })]
                 }
                 Phi::EnforceNext { players, formula } => {
-                    let moves: Vec<usize> = self.game_structure.move_count(*state);
-                    VarsIterator::new(moves, players.iter().copied().collect())
+                    let moves = self.game_structure.move_count(*state);
+                    PmovesIterator::new(moves, players.iter().copied().collect())
                         .map(|pmove| {
                             let targets: Vec<ATLVertex> =
                                 DeltaIterator::new(&self.game_structure, *state, &pmove)
@@ -425,20 +415,19 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                                         formula: formula.clone(),
                                     })
                                     .collect();
-                            Edges::HYPER(HyperEdge {
+                            Edge::HYPER(HyperEdge {
                                 source: vert.clone(),
+                                pmove: Some(pmove),
                                 targets,
                             })
                         })
-                        .collect::<HashSet<Edges<ATLVertex>>>()
+                        .collect::<Vec<Edge<ATLVertex>>>()
                 }
                 Phi::DespiteUntil {
                     players,
                     pre,
                     until,
                 } => {
-                    let mut edges = HashSet::new();
-
                     // `pre`-target
                     // "Is `pre` formula satisfied now?"
                     let pre = ATLVertex::FULL {
@@ -446,39 +435,58 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                         formula: pre.clone(),
                     };
 
+                    // Together with the `pre` target is all the possible moves by other players,
+                    // but it is important that `pre` is the first target
                     let moves = self.game_structure.move_count(*state);
-                    let mut targets: Vec<ATLVertex> =
-                        VarsIterator::new(moves, players.iter().cloned().collect())
-                            .map(|pmove| ATLVertex::PARTIAL {
+                    let mut targets: Vec<ATLVertex> = std::iter::once(pre)
+                        .chain(
+                            PmovesIterator::new(moves, players.iter().cloned().collect()).map(
+                                |pmove| ATLVertex::PARTIAL {
+                                    state: *state,
+                                    partial_move: pmove,
+                                    formula: vert.formula(),
+                                },
+                            ),
+                        )
+                        .collect();
+
+                    vec![
+                        // `until`-formula branch
+                        // "Is the `until` formula satisfied now?"
+                        Edge::HYPER(HyperEdge {
+                            source: vert.clone(),
+                            pmove: None,
+                            targets: vec![ATLVertex::FULL {
                                 state: *state,
-                                partial_move: pmove,
-                                formula: vert.formula(),
-                            })
-                            .collect();
-                    targets.push(pre);
-
-                    edges.insert(Edges::HYPER(HyperEdge {
-                        source: vert.clone(),
-                        targets,
-                    }));
-
-                    // `until`-formula branch
-                    // "Is the `until` formula satisfied now?"
-                    edges.insert(Edges::HYPER(HyperEdge {
-                        source: vert.clone(),
-                        targets: vec![ATLVertex::FULL {
-                            state: *state,
-                            formula: until.clone(),
-                        }],
-                    }));
-
-                    edges
+                                formula: until.clone(),
+                            }],
+                        }),
+                        // Other branches where pre is satisfied
+                        Edge::HYPER(HyperEdge {
+                            source: vert.clone(),
+                            pmove: None,
+                            targets,
+                        }),
+                    ]
                 }
                 Phi::EnforceUntil {
                     players,
                     pre,
                     until,
                 } => {
+                    let mut edges = vec![
+                        // `until`-formula branch
+                        // "Is the `until` formula satisfied now?"
+                        Edge::HYPER(HyperEdge {
+                            source: vert.clone(),
+                            pmove: None,
+                            targets: vec![ATLVertex::FULL {
+                                state: *state,
+                                formula: until.clone(),
+                            }],
+                        }),
+                    ];
+
                     // `pre`-target
                     // "Is `pre` formula satisfied now?"
                     let pre = ATLVertex::FULL {
@@ -487,33 +495,28 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                     };
 
                     let moves = self.game_structure.move_count(*state);
-                    let mut edges: HashSet<Edges<ATLVertex>> =
-                        VarsIterator::new(moves, players.iter().copied().collect())
-                            .map(|pmove| {
-                                let mut targets: Vec<ATLVertex> =
-                                    DeltaIterator::new(&self.game_structure, *state, &pmove)
-                                        .map(|state| ATLVertex::FULL {
+                    edges.extend(
+                        PmovesIterator::new(moves, players.iter().copied().collect()).map(
+                            |pmove| {
+                                // Together with the `pre` target is all the possible moves by other players,
+                                // but it is important that `pre` is the first target
+                                let delta =
+                                    DeltaIterator::new(&self.game_structure, *state, &pmove).map(
+                                        |state| ATLVertex::FULL {
                                             state,
                                             formula: formula.clone(),
-                                        })
-                                        .collect();
-                                targets.push(pre.clone());
-                                Edges::HYPER(HyperEdge {
+                                        },
+                                    );
+                                let mut targets: Vec<ATLVertex> =
+                                    std::iter::once(pre.clone()).chain(delta).collect();
+                                Edge::HYPER(HyperEdge {
                                     source: vert.clone(),
+                                    pmove: Some(pmove),
                                     targets,
                                 })
-                            })
-                            .collect();
-
-                    // `until`-formula branch
-                    // "Is the `until` formula satisfied now?"
-                    edges.insert(Edges::HYPER(HyperEdge {
-                        source: vert.clone(),
-                        targets: vec![ATLVertex::FULL {
-                            state: *state,
-                            formula: until.clone(),
-                        }],
-                    }));
+                            },
+                        ),
+                    );
 
                     edges
                 }
@@ -521,46 +524,59 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                     players,
                     formula: subformula,
                 } => {
-                    let mut edges = HashSet::new();
-
                     // Partial targets with same formula
-                    // "Is the formula also satisfied in the next state?"
+                    // "Is the formula satisfied in the next state instead?"
                     let moves = self.game_structure.move_count(*state);
                     let targets: Vec<ATLVertex> =
-                        VarsIterator::new(moves, players.iter().cloned().collect())
+                        PmovesIterator::new(moves, players.iter().cloned().collect())
                             .map(|pmove| ATLVertex::PARTIAL {
                                 state: *state,
                                 partial_move: pmove,
                                 formula: formula.clone(),
                             })
                             .collect();
-                    edges.insert(Edges::HYPER(HyperEdge {
-                        source: vert.clone(),
-                        targets,
-                    }));
 
-                    // sub-formula target
-                    // "Is the sub formula satisfied in current state?"
-                    edges.insert(Edges::HYPER(HyperEdge {
-                        source: vert.clone(),
-                        targets: vec![ATLVertex::FULL {
-                            state: *state,
-                            formula: subformula.clone(),
-                        }],
-                    }));
-
-                    edges
+                    vec![
+                        // sub-formula target
+                        // "Is the sub formula satisfied in current state?"
+                        Edge::HYPER(HyperEdge {
+                            source: vert.clone(),
+                            pmove: None,
+                            targets: vec![ATLVertex::FULL {
+                                state: *state,
+                                formula: subformula.clone(),
+                            }],
+                        }),
+                        Edge::HYPER(HyperEdge {
+                            source: vert.clone(),
+                            pmove: None,
+                            targets,
+                        }),
+                    ]
                 }
                 Phi::EnforceEventually {
                     players,
                     formula: subformula,
                 } => {
+                    let mut edges = vec![
+                        // sub-formula target
+                        // "Is the sub formula satisfied in current state?"
+                        Edge::HYPER(HyperEdge {
+                            source: vert.clone(),
+                            pmove: None,
+                            targets: vec![ATLVertex::FULL {
+                                state: *state,
+                                formula: subformula.clone(),
+                            }],
+                        }),
+                    ];
+
                     // Successor states with same formula
-                    // "Is the formula also satisfied in the next state?"
+                    // "Is the formula satisfied in the next state instead?"
                     let moves = self.game_structure.move_count(*state);
-                    let mut edges: HashSet<Edges<ATLVertex>> =
-                        VarsIterator::new(moves, players.iter().copied().collect())
-                            .map(|pmove| {
+                    edges.extend(
+                        PmovesIterator::new(moves, players.iter().copied().collect()).map(
+                            |pmove| {
                                 let targets: Vec<ATLVertex> =
                                     DeltaIterator::new(&self.game_structure, *state, &pmove)
                                         .map(|state| ATLVertex::FULL {
@@ -568,22 +584,14 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                                             formula: formula.clone(),
                                         })
                                         .collect();
-                                Edges::HYPER(HyperEdge {
+                                Edge::HYPER(HyperEdge {
                                     source: vert.clone(),
+                                    pmove: Some(pmove),
                                     targets,
                                 })
-                            })
-                            .collect();
-
-                    // sub-formula target
-                    // "Is the sub formula satisfied in current state?"
-                    edges.insert(Edges::HYPER(HyperEdge {
-                        source: vert.clone(),
-                        targets: vec![ATLVertex::FULL {
-                            state: *state,
-                            formula: subformula.clone(),
-                        }],
-                    }));
+                            },
+                        ),
+                    );
 
                     edges
                 }
@@ -591,37 +599,35 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                     players,
                     formula: subformula,
                 } => {
-                    let mut edges = HashSet::new();
-                    edges.insert(Edges::NEGATION(NegationEdge {
+                    vec![Edge::NEGATION(NegationEdge {
                         source: vert.clone(),
                         target: ATLVertex::FULL {
                             state: *state,
+                            // Modified formula, switching to minimum-fixed point domain
                             formula: Arc::new(Phi::EnforceUntil {
                                 players: players.clone(),
                                 pre: Arc::new(Phi::True),
                                 until: Arc::new(Phi::Not(subformula.clone())),
                             }),
                         },
-                    }));
-                    edges
+                    })]
                 }
                 Phi::EnforceInvariant {
                     players,
                     formula: subformula,
                 } => {
-                    let mut edges = HashSet::new();
-                    edges.insert(Edges::NEGATION(NegationEdge {
+                    vec![Edge::NEGATION(NegationEdge {
                         source: vert.clone(),
                         target: ATLVertex::FULL {
                             state: *state,
+                            // Modified formula, switching to minimum-fixed point
                             formula: Arc::new(Phi::DespiteUntil {
                                 players: players.clone(),
                                 pre: Arc::new(Phi::True),
                                 until: Arc::new(Phi::Not(subformula.clone())),
                             }),
                         },
-                    }));
-                    edges
+                    })]
                 }
             },
             ATLVertex::PARTIAL {
@@ -634,12 +640,13 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                         state,
                         formula: formula.clone(),
                     }];
-                    Edges::HYPER(HyperEdge {
+                    Edge::HYPER(HyperEdge {
                         source: vert.clone(),
+                        pmove: Some(partial_move.clone()),
                         targets,
                     })
                 })
-                .collect::<HashSet<Edges<ATLVertex>>>(),
+                .collect::<Vec<Edge<ATLVertex>>>(),
         }
     }
 }
@@ -648,7 +655,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
 mod test {
     use crate::atl::common::DynVec;
     use crate::atl::dependencygraph::{
-        DeltaIterator, PartialMoveChoice, PartialMoveIterator, VarsIterator,
+        DeltaIterator, PartialMoveChoice, PartialMoveIterator, PmovesIterator,
     };
     use crate::atl::gamestructure::EagerGameStructure;
     use std::collections::HashSet;
@@ -676,7 +683,7 @@ mod test {
         let mut players = HashSet::new();
         players.insert(0);
         players.insert(2);
-        let mut iter = VarsIterator::new(moves, players);
+        let mut iter = PmovesIterator::new(moves, players);
 
         assert_eq!(
             &iter.next(),
@@ -716,7 +723,7 @@ mod test {
     fn vars_iterator_02() {
         let mut players = HashSet::new();
         players.insert(2);
-        let mut iter = VarsIterator::new(vec![2, 3, 3], players);
+        let mut iter = PmovesIterator::new(vec![2, 3, 3], players);
 
         let value = iter.next().unwrap();
         assert_eq!(value[0], PartialMoveChoice::RANGE(2));
@@ -743,7 +750,7 @@ mod test {
         let mut players = HashSet::new();
         players.insert(0);
         players.insert(1);
-        let mut iter = VarsIterator::new(vec![3, 3], players);
+        let mut iter = PmovesIterator::new(vec![3, 3], players);
 
         let value = iter.next().unwrap();
         assert_eq!(value[0], PartialMoveChoice::SPECIFIC(0));

--- a/atl-checker/src/common.rs
+++ b/atl-checker/src/common.rs
@@ -1,3 +1,4 @@
+use crate::atl::dependencygraph::PartialMove;
 use std::fmt::{Display, Formatter};
 use std::hash::Hash;
 
@@ -31,6 +32,7 @@ impl Display for VertexAssignment {
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct HyperEdge<V: Hash + Eq + PartialEq + Clone> {
     pub source: V,
+    pub pmove: Option<PartialMove>,
     pub targets: Vec<V>,
 }
 
@@ -41,15 +43,15 @@ pub struct NegationEdge<V: Hash + Eq + PartialEq + Clone> {
 }
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
-pub enum Edges<V: Hash + Eq + PartialEq + Clone> {
+pub enum Edge<V: Hash + Eq + PartialEq + Clone> {
     HYPER(HyperEdge<V>),
     NEGATION(NegationEdge<V>),
 }
 
-impl<V: Hash + Eq + PartialEq + Clone> Edges<V> {
+impl<V: Hash + Eq + PartialEq + Clone> Edge<V> {
     /// Returns true if this is a hyper edge
     pub fn is_hyper(&self) -> bool {
-        matches!(self, Edges::HYPER(_))
+        matches!(self, Edge::HYPER(_))
     }
 
     /// Returns true if this is a negation edge
@@ -60,8 +62,8 @@ impl<V: Hash + Eq + PartialEq + Clone> Edges<V> {
     /// Returns the source vertex of this edge
     pub fn source(&self) -> &V {
         match self {
-            Edges::HYPER(e) => &e.source,
-            Edges::NEGATION(e) => &e.source,
+            Edge::HYPER(e) => &e.source,
+            Edge::NEGATION(e) => &e.source,
         }
     }
 }

--- a/atl-checker/src/edg.rs
+++ b/atl-checker/src/edg.rs
@@ -7,7 +7,7 @@ use std::thread;
 
 use crate::com::{Broker, BrokerManager, ChannelBroker};
 use crate::common::{
-    Edges, HyperEdge, Message, MsgToken, NegationEdge, Token, VertexAssignment, WorkerId,
+    Edge, HyperEdge, Message, MsgToken, NegationEdge, Token, VertexAssignment, WorkerId,
 };
 use crate::search_strategy::{SearchStrategy, SearchStrategyBuilder};
 use std::cmp::max;
@@ -22,7 +22,7 @@ pub trait Vertex: Hash + Eq + PartialEq + Clone + Display + Debug {}
 pub trait ExtendedDependencyGraph<V: Vertex> {
     /// Return out going edges from `vertex`.
     /// This will be cached on each worker.
-    fn succ(&self, vertex: &V) -> HashSet<Edges<V>>;
+    fn succ(&self, vertex: &V) -> Vec<Edge<V>>;
 }
 
 pub fn distributed_certain_zero<
@@ -75,7 +75,7 @@ struct Worker<B: Broker<V> + Debug, G: ExtendedDependencyGraph<V>, V: Vertex, S:
     /// Greatest known assignment for vertices.
     /// Order is as follow UNEXPLORED/None < UNDECIDED < {TRUE, FALSE}. Once a vertex has been assigned TRUE or FALSE it will never change assignment.
     assignment: HashMap<V, VertexAssignment>,
-    depends: HashMap<V, HashSet<Edges<V>>>,
+    depends: HashMap<V, HashSet<Edge<V>>>,
     /// Map of workers that need to be sent a message once the final assignment of a vertex is known.
     interests: HashMap<V, HashSet<WorkerId>>,
     /// Greatest number of negation edges in any path from v0 to the given vertex.
@@ -90,7 +90,7 @@ struct Worker<B: Broker<V> + Debug, G: ExtendedDependencyGraph<V>, V: Vertex, S:
     /// The logic of handling which edges have been deleted from a vertex is delegated to Worker instead of having to be duplicated in every implementation of ExtendedDependencyGraph.
     /// The first time succ is called on a vertex the call goes to the ExtendedDependencyGraph implementation, and the result is saved in successors.
     /// In all subsequent calls the vertex edges will be taken from the HashMap. This allows for modification of the output of the succ function.
-    successors: HashMap<V, HashSet<Edges<V>>>,
+    successors: HashMap<V, HashSet<Edge<V>>>,
     edg: G,
     /// Used on the leader as a gate to avoid starting a round of the token ring if one is already in progress.
     token_in_circulation: bool,
@@ -141,14 +141,14 @@ impl<
             v0,
             running: true,
             assignment: HashMap::new(),
-            depends: HashMap::<V, HashSet<Edges<V>>>::new(),
+            depends: HashMap::<V, HashSet<Edge<V>>>::new(),
             interests: HashMap::<V, HashSet<WorkerId>>::new(),
             msg_queue: VecDeque::new(),
             unsafe_neg_edges: Vec::<Vec<NegationEdge<V>>>::new(),
             strategy,
             depth: HashMap::<V, u32>::new(),
             broker,
-            successors: HashMap::<V, HashSet<Edges<V>>>::new(),
+            successors: HashMap::<V, HashSet<Edge<V>>>::new(),
             edg,
             token_in_circulation: false,
             dirty: false,
@@ -365,10 +365,10 @@ impl<
             return true;
         } else if let Some(edge) = self.strategy.next() {
             match edge {
-                Edges::HYPER(e) => {
+                Edge::HYPER(e) => {
                     self.process_hyper_edge(e);
                 }
-                Edges::NEGATION(e) => {
+                Edge::NEGATION(e) => {
                     self.process_negation_edge(e);
                 }
             }
@@ -489,7 +489,7 @@ impl<
 
         // Line 4
         if any_target {
-            self.delete_edge(Edges::HYPER(edge));
+            self.delete_edge(Edge::HYPER(edge));
             return;
         }
 
@@ -500,12 +500,12 @@ impl<
                 Some(VertexAssignment::UNDECIDED) => {
                     // UNDECIDED
                     // Line 7
-                    self.add_depend(target, Edges::HYPER(edge.clone()));
+                    self.add_depend(target, Edge::HYPER(edge.clone()));
                 }
                 None => {
                     // UNEXPLORED
                     // Line 7
-                    self.add_depend(target, Edges::HYPER(edge.clone()));
+                    self.add_depend(target, Edge::HYPER(edge.clone()));
                     // Line 8
                     self.explore(target);
                 }
@@ -515,7 +515,7 @@ impl<
     }
 
     /// Mark `dependency` as a prerequisite for finding the final assignment of `vertex`
-    fn add_depend(&mut self, vertex: &V, dependency: Edges<V>) {
+    fn add_depend(&mut self, vertex: &V, dependency: Edge<V>) {
         // Update the depth
         let old_vertex_depth = *self.depth.get(vertex).unwrap_or(&0);
         let source_depth = *self.depth.get(dependency.source()).unwrap_or(&0);
@@ -534,7 +534,7 @@ impl<
     }
 
     /// Remove `dependency` as a prerequisite for finding the final assignment of `vertex`
-    fn remove_depend(&mut self, vertex: &V, dependency: Edges<V>) {
+    fn remove_depend(&mut self, vertex: &V, dependency: Edge<V>) {
         if let Some(dependencies) = self.depends.get_mut(vertex) {
             dependencies.remove(&dependency);
         }
@@ -550,7 +550,7 @@ impl<
                 // UNEXPLORED
                 // Line 6
                 trace!(?edge, assignment = "UNEXPLORED", "processing negation edge");
-                self.add_depend(&edge.target, Edges::NEGATION(edge.clone()));
+                self.add_depend(&edge.target, Edge::NEGATION(edge.clone()));
                 self.queue_unsafe_negation(edge.clone());
                 self.explore(&edge.target);
             }
@@ -565,7 +565,7 @@ impl<
                         // must be from another branch of the EDG. Hence, we add this edge as an
                         // unsafe dependency
                         trace!(?edge, assignment = ?VertexAssignment::UNDECIDED, "processing negation edge");
-                        self.add_depend(&edge.target, Edges::NEGATION(edge.clone()));
+                        self.add_depend(&edge.target, Edge::NEGATION(edge.clone()));
                         self.queue_unsafe_negation(edge.clone())
                     }
                 }
@@ -575,7 +575,7 @@ impl<
                 }
                 VertexAssignment::TRUE => {
                     trace!(?edge, assignment = ?VertexAssignment::TRUE, "processing negation edge");
-                    self.delete_edge(Edges::NEGATION(edge))
+                    self.delete_edge(Edge::NEGATION(edge))
                 }
             },
         }
@@ -702,7 +702,7 @@ impl<
     }
 
     /// Helper function for deleting edges from a vertex.
-    fn delete_edge(&mut self, edge: Edges<V>) {
+    fn delete_edge(&mut self, edge: Edge<V>) {
         let source = edge.source();
 
         // Remove edge from source
@@ -725,33 +725,30 @@ impl<
 
         match edge {
             // Line 4-6
-            Edges::HYPER(ref edge) => {
+            Edge::HYPER(ref edge) => {
                 debug!(source = ?edge, targets = ?edge.targets, "remove hyper-edge as dependency");
                 for target in &edge.targets {
-                    self.remove_depend(target, Edges::HYPER(edge.clone()))
+                    self.remove_depend(target, Edge::HYPER(edge.clone()))
                 }
             }
             // Line 7-8
-            Edges::NEGATION(ref edge) => {
+            Edge::NEGATION(ref edge) => {
                 debug!(source = ?edge, target = ?edge.target, "remove negation-edge as dependency");
-                self.remove_depend(&edge.target, Edges::NEGATION(edge.clone()))
+                self.remove_depend(&edge.target, Edge::NEGATION(edge.clone()))
             }
         }
     }
 
     /// Wraps the ExtendedDependencyGraph::succ(v) with caching allowing edges to be deleted.
     /// See documentation for the `successors` field.
-    fn succ(&mut self, vertex: &V) -> HashSet<Edges<V>> {
+    fn succ(&mut self, vertex: &V) -> Vec<Edge<V>> {
         if let Some(successors) = self.successors.get(vertex) {
-            debug!(?vertex, ?successors, known_vertex = true, "edg::succ");
-            #[cfg(feature = "use-counts")]
-            eprintln!("worker succ cached");
-            // List of successors is already allocated for the vertex
-            successors.clone()
+            panic!("Used cached successors instead")
         } else {
             // Setup the successors list the first time it is requested
             let successors = self.edg.succ(vertex);
-            self.successors.insert(vertex.clone(), successors.clone());
+            let successor_set = successors.iter().cloned().collect();
+            self.successors.insert(vertex.clone(), successor_set);
             debug!(
                 ?vertex,
                 ?successors,
@@ -774,7 +771,7 @@ mod test {
 
     use core::fmt::Formatter;
 
-    use crate::common::{Edges, HyperEdge, NegationEdge, VertexAssignment};
+    use crate::common::{Edge, HyperEdge, NegationEdge, VertexAssignment};
     use crate::edg::{distributed_certain_zero, ExtendedDependencyGraph, Vertex};
     use crate::search_strategy::bfs::BreadthFirstSearchBuilder;
 

--- a/atl-checker/src/main.rs
+++ b/atl-checker/src/main.rs
@@ -23,7 +23,7 @@ use tracing::trace;
 use crate::atl::dependencygraph::{ATLDependencyGraph, ATLVertex};
 use crate::atl::formula::{ATLExpressionParser, Phi};
 use crate::atl::gamestructure::{EagerGameStructure, GameStructure};
-use crate::common::Edges;
+use crate::common::Edge;
 use crate::edg::{distributed_certain_zero, Vertex};
 use crate::lcgs::ast::DeclKind;
 use crate::lcgs::ir::intermediate::IntermediateLCGS;

--- a/atl-checker/src/printer.rs
+++ b/atl-checker/src/printer.rs
@@ -1,4 +1,4 @@
-use crate::common::Edges;
+use crate::common::Edge;
 use crate::edg::{ExtendedDependencyGraph, Vertex};
 use std::collections::hash_map::DefaultHasher;
 use std::collections::{HashSet, VecDeque};
@@ -46,7 +46,7 @@ pub fn print_graph<V: Vertex, G: ExtendedDependencyGraph<V>, W: Write>(
             let hyper_id = hash_name(&edge);
 
             match edge {
-                Edges::HYPER(hyper) => {
+                Edge::HYPER(hyper) => {
                     print_vertex(&hyper.source, &mut output)?;
 
                     if hyper.targets.is_empty() {
@@ -103,7 +103,7 @@ pub fn print_graph<V: Vertex, G: ExtendedDependencyGraph<V>, W: Write>(
                         }
                     }
                 }
-                Edges::NEGATION(neg) => {
+                Edge::NEGATION(neg) => {
                     print_vertex(&neg.source, &mut output)?;
 
                     output.write_all(

--- a/atl-checker/src/search_strategy/bfs.rs
+++ b/atl-checker/src/search_strategy/bfs.rs
@@ -1,4 +1,4 @@
-use crate::common::Edges;
+use crate::common::Edge;
 use crate::edg::Vertex;
 use crate::search_strategy::{SearchStrategy, SearchStrategyBuilder};
 use std::collections::{HashSet, VecDeque};
@@ -6,7 +6,7 @@ use std::collections::{HashSet, VecDeque};
 /// Breadth-first search strategy traverses vertices close to the root first, using a FIFO
 /// (first in, first out) data structure.
 pub struct BreadthFirstSearch<V: Vertex> {
-    queue: VecDeque<Edges<V>>,
+    queue: VecDeque<Edge<V>>,
 }
 
 impl<V: Vertex> BreadthFirstSearch<V> {
@@ -18,11 +18,11 @@ impl<V: Vertex> BreadthFirstSearch<V> {
 }
 
 impl<V: Vertex> SearchStrategy<V> for BreadthFirstSearch<V> {
-    fn next(&mut self) -> Option<Edges<V>> {
+    fn next(&mut self) -> Option<Edge<V>> {
         self.queue.pop_front()
     }
 
-    fn queue_new_edges(&mut self, edges: HashSet<Edges<V>>) {
+    fn queue_new_edges(&mut self, edges: Vec<Edge<V>>) {
         for edge in edges {
             self.queue.push_back(edge);
         }

--- a/atl-checker/src/search_strategy/mod.rs
+++ b/atl-checker/src/search_strategy/mod.rs
@@ -1,6 +1,6 @@
 pub mod bfs;
 
-use crate::common::{Edges, NegationEdge};
+use crate::common::{Edge, NegationEdge};
 use crate::edg::Vertex;
 use std::collections::HashSet;
 
@@ -10,22 +10,20 @@ use std::collections::HashSet;
 /// that prioritises certain reasons queueing differently.
 pub trait SearchStrategy<V: Vertex> {
     /// Returns the next edge to be processed, or none if there are no safe edges to process.
-    fn next(&mut self) -> Option<Edges<V>>;
+    fn next(&mut self) -> Option<Edge<V>>;
 
     /// Queue a set of safe edges with the heuristic
-    fn queue_new_edges(&mut self, edges: HashSet<Edges<V>>);
+    fn queue_new_edges(&mut self, edges: Vec<Edge<V>>);
 
     /// Queue a set of previously unsafe negation edges
     fn queue_released_edges(&mut self, edges: Vec<NegationEdge<V>>) {
         let mut edges = edges;
-        self.queue_new_edges(edges.drain(..).map(Edges::NEGATION).collect())
+        self.queue_new_edges(edges.drain(..).map(Edge::NEGATION).collect())
     }
 
     /// Requeue an edge because one of its targets was assigned a certain value
-    fn queue_back_propagation(&mut self, edge: Edges<V>) {
-        let mut set = HashSet::new();
-        set.insert(edge);
-        self.queue_new_edges(set)
+    fn queue_back_propagation(&mut self, edge: Edge<V>) {
+        self.queue_new_edges(vec![edge])
     }
 }
 

--- a/atl-checker/src/simple_edg.rs
+++ b/atl-checker/src/simple_edg.rs
@@ -65,7 +65,7 @@ macro_rules! simple_edg {
             fn succ(
                 &self,
                 vertex: &$vertex_name,
-            ) -> HashSet<Edges<$vertex_name>> {
+            ) -> Vec<Edge<$vertex_name>> {
                 simple_edg![@match vertex_name=$vertex_name, vertex $( $v => $( -> { $( $t ),* } )* $( .> $n )* );*;]
             }
         }
@@ -75,12 +75,13 @@ macro_rules! simple_edg {
         match $vertex {
             $($vertex_name::$v => {
                 #[allow(unused_mut)]
-                let mut successors = HashSet::new();
-                $(successors.insert(Edges::HYPER(HyperEdge {
+                let mut successors = vec![];
+                $(successors.push(Edge::HYPER(HyperEdge {
                     source: $vertex_name::$v,
+                    pmove: None,
                     targets: vec![$($vertex_name::$t),*],
                 }));)*
-                $(successors.insert(Edges::NEGATION(NegationEdge {
+                $(successors.push(Edge::NEGATION(NegationEdge {
                     source: $vertex_name::$v,
                     target: $vertex_name::$n,
                 }));)*


### PR DESCRIPTION
Our original plan was to make `succ` return an enum of structs such that we had full insight into the various edges produced by specific formulae as this would aid us create better analysis for heuristics and easier computation of partial strategies.

However, that would have affected the generallity of the algorithm as it forces all vertices to have ATL+CGS-like branches. For instance, our test EDGs are not generated from ATL+CGS, so they would not fit a similar struct. Instead, I chose to replace the HashSet with a Vec and introduce a defined order in `succ`. The order follows how we have previously drawn the successor edges, left-to-right. This order is similar to having the smallest edge or the smallest target first. Due to the nature of the successors, this order only matters for Until and eventually formulae.

As an alternative way to aid computation of partial strategies, this PR adds partial moves to hyper-edges where relevant.

Depends on #130 