### PR TITLE
Move CLI to separate crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
 members = [
     "atl-checker",
+    "cli",
 ]

--- a/atl-checker/Cargo.toml
+++ b/atl-checker/Cargo.toml
@@ -27,13 +27,8 @@ harness = false
 
 [dependencies]
 crossbeam-channel = "0.5.0"
-num_cpus = "1.13.0"
 pom = "3.2.0"
-clap = "2.33.3"
 serde = { version = "1.0.117", features = ["derive", "rc"] }
-serde_json = "1.0.59"
 tracing = "0.1"
-tracing-subscriber = "0.2.17"
 lazy_static = "1.4.0"
 joinery = "2.0.0"
-git-version = "0.3.4"

--- a/atl-checker/Cargo.toml
+++ b/atl-checker/Cargo.toml
@@ -21,6 +21,7 @@ use-counts = []
 [dev-dependencies]
 test-env-log = { version = "0.2.5", features = ["trace"], default-features = false }
 criterion = "0.3"
+tracing-subscriber = "0.2.17"
 
 [[bench]]
 name = "benchmark_solver"

--- a/atl-checker/src/atl/formula/mod.rs
+++ b/atl-checker/src/atl/formula/mod.rs
@@ -1,9 +1,9 @@
 pub mod game_formula;
-mod parser;
+pub mod parser;
 
 use crate::atl::common::{Player, Proposition};
 use crate::atl::formula::game_formula::GamePhi;
-pub(crate) use crate::atl::formula::parser::*;
+pub use crate::atl::formula::parser::*;
 use crate::atl::gamestructure::GameStructure;
 use joinery::prelude::*;
 use std::cmp::max;

--- a/atl-checker/src/lib.rs
+++ b/atl-checker/src/lib.rs
@@ -1,16 +1,17 @@
-extern crate num_cpus;
 #[macro_use]
 extern crate serde;
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
 extern crate tracing;
+
 #[macro_use]
 mod simple_edg;
-
 pub mod atl;
 mod com;
 mod common;
 pub mod edg;
 pub mod lcgs;
-mod printer;
+#[cfg(feature = "graph-printer")]
+pub mod printer;
+pub mod solve_set;

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "cli"
+version = "0.1.0"
+authors = ["Jener Rasmussen <jener@jener.dk>"]
+edition = "2018"
+
+[dependencies]
+num_cpus = "1.13.0"
+git-version = "0.3.4"
+clap = "2.33.3"
+tracing = "0.1"
+tracing-subscriber = "0.2.17"
+serde_json = "1.0.59"
+atl-checker = { path = "../atl-checker", version = "0.1.0"}

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,16 @@
 [package]
 name = "cli"
 version = "0.1.0"
-authors = ["Jener Rasmussen <jener@jener.dk>"]
+authors = [
+    "d702e20 <d702e20@cs.aau.dk>",
+    "d802f21 <d802f21@cs.aau.dk>",
+    "Asger Weirsøe <aweirs15@student.aau.dk>",
+    "Falke Carlsen <falke.cs@gmail.com>",
+    "Jener Rasmussen <jener@jener.dk>",
+    "Lars Bo Frydenskov <lfryde17@student.aau.dk>",
+    "Mathias Mehl Sørensen <mmsa17@student.aau.dk>",
+    "Nicolaj Østerby Jensen <naje17@student.aau.dk>",
+]
 edition = "2018"
 
 [dependencies]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,10 +1,6 @@
 #[no_link]
 extern crate git_version;
-#[macro_use]
-extern crate lazy_static;
 extern crate num_cpus;
-#[macro_use]
-extern crate serde;
 #[macro_use]
 extern crate tracing;
 
@@ -18,29 +14,17 @@ use clap::{App, Arg, ArgMatches, SubCommand};
 use git_version::git_version;
 use tracing::trace;
 
-use crate::atl::dependencygraph::{ATLDependencyGraph, ATLVertex};
-use crate::atl::formula::game_formula::GamePhi;
-use crate::atl::formula::{ATLExpressionParser, Phi};
-use crate::atl::gamestructure::{EagerGameStructure, GameStructure};
-use crate::edg::distributed_certain_zero;
-use crate::lcgs::ast::DeclKind;
-use crate::lcgs::ir::intermediate::IntermediateLCGS;
-use crate::lcgs::ir::symbol_table::Owner;
-use crate::lcgs::parse::parse_lcgs;
-#[cfg(feature = "graph-printer")]
-use crate::printer::print_graph;
-use crate::solve_set::minimum_solve_set;
-
-#[macro_use]
-mod simple_edg;
-mod atl;
-mod com;
-mod common;
-mod edg;
-mod lcgs;
-#[cfg(feature = "graph-printer")]
-mod printer;
-mod solve_set;
+use atl_checker::atl::dependencygraph::{ATLDependencyGraph, ATLVertex};
+use atl_checker::atl::formula::game_formula::GamePhi;
+use atl_checker::atl::formula::{ATLExpressionParser, Phi};
+use atl_checker::atl::gamestructure::{EagerGameStructure, GameStructure};
+use atl_checker::edg::distributed_certain_zero;
+use atl_checker::lcgs::ast::DeclKind;
+use atl_checker::lcgs::ir::intermediate::IntermediateLCGS;
+use atl_checker::lcgs::ir::symbol_table::Owner;
+use atl_checker::lcgs::parse::parse_lcgs;
+use atl_checker::printer::print_graph;
+use atl_checker::solve_set::minimum_solve_set;
 
 const PKG_NAME: &str = env!("CARGO_PKG_NAME");
 const AUTHORS: &str = env!("CARGO_PKG_AUTHORS");
@@ -297,7 +281,7 @@ fn load_formula<A: ATLExpressionParser>(path: &str, format: FormulaFormat, expr_
             exit(1);
         }),
         FormulaFormat::ATL => {
-            let result = atl::formula::parse_phi(expr_parser, &raw_phi);
+            let result = atl_checker::atl::formula::parse_phi(expr_parser, &raw_phi);
             result.unwrap_or_else(|err| {
                 eprintln!("Invalid ATL formula provided:\n\n{}", err);
                 exit(1)


### PR DESCRIPTION
Moves the commandline interface into a separate crate. This is step on the way to create alternative frontends, and for using the model checker as a library in other projects.

There haven't been made any meaningful decision on which APIs to make public, this is left as future work.