### PR TITLE
Restructure subcommand argument definition using CommonArgs trait

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cli"
+name = "atl-checker-cli"
 version = "0.1.0"
 authors = [
     "d702e20 <d702e20@cs.aau.dk>",
@@ -20,4 +20,4 @@ clap = "2.33.3"
 tracing = "0.1"
 tracing-subscriber = "0.2.17"
 serde_json = "1.0.59"
-atl-checker = { path = "../atl-checker", version = "0.1.0"}
+atl-checker = { path = "../atl-checker", version = "0.1.0" }

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -1,0 +1,72 @@
+use clap::{App, Arg};
+
+/// Trait that allows us to easily add common arguments to the CLI, avoiding duplicate code while
+/// remaining flexible in terms of which subcommands have which arguments
+pub(crate) trait CommonArgs {
+    fn add_input_model_arg(self) -> Self;
+    fn add_input_model_type_arg(self) -> Self;
+    fn add_formula_arg(self) -> Self;
+    fn add_formula_format_arg(self) -> Self;
+    fn add_output_arg(self, required: bool) -> Self;
+}
+
+/// Add the common arguments to clap::App
+impl CommonArgs for App<'_, '_> {
+    /// Adds "--input-model" as a required argument
+    fn add_input_model_arg(self) -> Self {
+        self.arg(
+            Arg::with_name("input_model")
+                .short("m")
+                .long("model")
+                .env("INPUT_MODEL")
+                .required(true)
+                .help("The input file to generate model from"),
+        )
+    }
+
+    /// Adds "--model-type" as an optional argument
+    fn add_input_model_type_arg(self) -> Self {
+        self.arg(
+            Arg::with_name("model_type")
+                .short("t")
+                .long("model-type")
+                .env("MODEL_TYPE")
+                .help("The type of input file given {{lcgs, json}}"),
+        )
+    }
+
+    /// Adds "--formula" as a required argument
+    fn add_formula_arg(self) -> Self {
+        self.arg(
+            Arg::with_name("formula")
+                .short("f")
+                .long("formula")
+                .env("FORMULA")
+                .required(true)
+                .help("The formula to check for"),
+        )
+    }
+
+    /// Adds "--formula-format" as an optional argument
+    fn add_formula_format_arg(self) -> Self {
+        self.arg(
+            Arg::with_name("formula_format")
+                .short("y")
+                .long("formula-format")
+                .env("FORMULA_FORMAT")
+                .help("The format of ATL formula file given {{json, text}}"),
+        )
+    }
+
+    /// Adds "--output" as an argument
+    fn add_output_arg(self, required: bool) -> Self {
+        self.arg(
+            Arg::with_name("output")
+                .short("o")
+                .long("output")
+                .env("OUTPUT")
+                .required(required)
+                .help("The path to write output to"),
+        )
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -317,13 +317,22 @@ fn get_model_type_from_args(args: &ArgMatches) -> Result<ModelType, String> {
 }
 
 /// Determine the formula format (either "json" or "atl") by reading the
-/// --formula_format argument. If none is given, we default to ATL
+/// --formula_format argument. If none is given, we try to infer it from the file extension
 fn get_formula_format_from_args(args: &ArgMatches) -> Result<FormulaFormat, String> {
     match args.value_of("formula_format") {
         Some("json") => Ok(FormulaFormat::JSON),
         Some("atl") => Ok(FormulaFormat::ATL),
-        // Default value in case user did not give one
-        None => Ok(FormulaFormat::ATL),
+        None => {
+            // Infer format from file extension
+            let formula_path = args.value_of("formula").unwrap();
+            if formula_path.ends_with(".atl") {
+                Ok(FormulaFormat::ATL)
+            } else if formula_path.ends_with(".json") {
+                Ok(FormulaFormat::JSON)
+            } else {
+                Err("Cannot infer formula format from file the extension. You can specify it with '--model_type=MODEL_TYPE'".to_string())
+            }
+        },
         Some(format) => Err(format!("Invalid formula format '{}' specified with --formula_format. Use either \"atl\" or \"json\" [default is \"atl\"].", format)),
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -429,6 +429,9 @@ fn parse_arguments() -> ArgMatches<'static> {
     if cfg!(feature = "graph-printer") {
         app = app.subcommand(
             SubCommand::with_name("graph")
+                .about(
+                    "Outputs a Graphviz DOT graph of the EDG generated from an ATL query and a CGS",
+                )
                 .add_input_model_arg()
                 .add_input_model_type_arg()
                 .add_formula_arg()


### PR DESCRIPTION
This PR introduces a CommonArgs trait, which adds functions to add our commonly used arguments (e.g. `--input-model` and `--model-type`) to our favorite command parser. This allows us to be more flexible, while avoid duplicate code. E.g. we can have one subcommand where `--output` is valid, and others where it is not, and the difference is one line of code.

The trait is implemented for `clap::App`.

This PR also adds formula format inference from file extension.