### PR TITLE
Allow SearchStrategy to modify edges during exploration

### DIFF
--- a/atl-checker/src/algorithms/certain_zero/mod.rs
+++ b/atl-checker/src/algorithms/certain_zero/mod.rs
@@ -431,7 +431,21 @@ impl<
 
         // Line 3
         if self.is_owner(vertex) {
-            let successors = self.succ(vertex); // Line 4
+            let successors = self.strategy.modify(self.edg.succ(vertex)); // Line 4
+
+            debug!(
+                ?vertex,
+                ?successors,
+                known_vertex = false,
+                "loaded successors from EDG"
+            );
+            #[cfg(feature = "use-counts")]
+            eprintln!("worker succ generated");
+
+            // Cache successors
+            let successor_set = successors.iter().cloned().collect();
+            self.successors.insert(vertex.clone(), successor_set);
+
             if successors.is_empty() {
                 // Line 4
                 // The vertex has no outgoing edges, so we assign it false
@@ -703,19 +717,18 @@ impl<
         // Remove edge from source
         self.successors.get_mut(source).unwrap().remove(&edge);
 
-        match self.successors.get(source) {
-            None => panic!("successors should have been filled, or at least have a empty vector"),
-            Some(successors) => {
-                // Line 3
-                if successors.is_empty() {
-                    trace!(
-                        ?source,
-                        assignment = ?VertexAssignment::FALSE,
-                        "no more successors, final assignment is FALSE"
-                    );
-                    self.final_assign(source, VertexAssignment::FALSE);
-                }
-            }
+        if self
+            .successors
+            .get(source)
+            .expect("successors should have been filled, or at least have a empty vector")
+            .is_empty()
+        {
+            trace!(
+                ?source,
+                assignment = ?VertexAssignment::FALSE,
+                "no more successors, final assignment is FALSE"
+            );
+            self.final_assign(source, VertexAssignment::FALSE);
         }
 
         match edge {
@@ -731,28 +744,6 @@ impl<
                 debug!(source = ?edge, target = ?edge.target, "remove negation-edge as dependency");
                 self.remove_depend(&edge.target, Edge::NEGATION(edge.clone()))
             }
-        }
-    }
-
-    /// Wraps the ExtendedDependencyGraph::succ(v) with caching allowing edges to be deleted.
-    /// See documentation for the `successors` field.
-    fn succ(&mut self, vertex: &V) -> Vec<Edge<V>> {
-        if let Some(_successors) = self.successors.get(vertex) {
-            panic!("Used cached successors instead")
-        } else {
-            // Setup the successors list the first time it is requested
-            let successors = self.edg.succ(vertex);
-            let successor_set = successors.iter().cloned().collect();
-            self.successors.insert(vertex.clone(), successor_set);
-            debug!(
-                ?vertex,
-                ?successors,
-                known_vertex = false,
-                "loaded successors from EDG"
-            );
-            #[cfg(feature = "use-counts")]
-            eprintln!("worker succ generated");
-            successors
         }
     }
 }

--- a/atl-checker/src/algorithms/certain_zero/search_strategy/mod.rs
+++ b/atl-checker/src/algorithms/certain_zero/search_strategy/mod.rs
@@ -24,6 +24,12 @@ pub trait SearchStrategy<V: Vertex> {
     fn queue_back_propagation(&mut self, edge: Edge<V>) {
         self.queue_new_edges(vec![edge])
     }
+
+    /// Modify the edges to benefit the search strategy. For instance, this could be a
+    /// rearrangement of the targets of the edges which results in better performance.
+    fn modify(&mut self, edge: Vec<Edge<V>>) -> Vec<Edge<V>> {
+        return edge;
+    }
 }
 
 /// A SearchStrategyBuilder is able to create an instance of a SearchStrategy.

--- a/atl-checker/src/algorithms/certain_zero/search_strategy/mod.rs
+++ b/atl-checker/src/algorithms/certain_zero/search_strategy/mod.rs
@@ -28,7 +28,7 @@ pub trait SearchStrategy<V: Vertex> {
     /// Modify the edges to benefit the search strategy. For instance, this could be a
     /// rearrangement of the targets of the edges which results in better performance.
     fn modify(&mut self, edge: Vec<Edge<V>>) -> Vec<Edge<V>> {
-        return edge;
+        edge
     }
 }
 


### PR DESCRIPTION
This change allows SearchStrategies to modify the edges. This will allow strategies to optimize the order of targets (linear heuristic will likely do this).

Due to the caching of successors, the edges can only be modified once (during exploration, right after generation), and I had to inline the previous `succ` function to achieve this.

Depends on #140