### PR TITLE
[P8-99] Fix clippy warnings

### DIFF
--- a/atl-checker/src/algorithms/certain_zero/com.rs
+++ b/atl-checker/src/algorithms/certain_zero/com.rs
@@ -68,7 +68,7 @@ impl<V: Hash + Eq + PartialEq + Clone> Broker<V> for ChannelBroker<V> {
 
     fn release(&self, depth: usize) {
         for i in 0..self.workers.len() {
-            self.send(i as u64, Message::RELEASE(depth))
+            self.send(i as u64, Message::Release(depth))
         }
     }
 
@@ -78,7 +78,7 @@ impl<V: Hash + Eq + PartialEq + Clone> Broker<V> for ChannelBroker<V> {
                 .workers
                 .get(to as usize)
                 .expect("receiver id out of bounds")
-                .send(Message::TERMINATE);
+                .send(Message::Terminate);
         }
     }
 

--- a/atl-checker/src/algorithms/certain_zero/common.rs
+++ b/atl-checker/src/algorithms/certain_zero/common.rs
@@ -7,24 +7,24 @@ pub type WorkerId = u64;
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum VertexAssignment {
     // UNEXPLORED is implemented as hashmap doesn't contain the key/vertex
-    UNDECIDED,
-    FALSE,
-    TRUE,
+    Undecided,
+    False,
+    True,
 }
 
 impl VertexAssignment {
     /// Returns true if the assignment is either true or false.
     pub fn is_certain(self) -> bool {
-        return matches!(self, VertexAssignment::TRUE | VertexAssignment::FALSE);
+        return matches!(self, VertexAssignment::True | VertexAssignment::False);
     }
 }
 
 impl Display for VertexAssignment {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            VertexAssignment::UNDECIDED => write!(f, "undecided"),
-            VertexAssignment::FALSE => write!(f, "false"),
-            VertexAssignment::TRUE => write!(f, "true"),
+            VertexAssignment::Undecided => write!(f, "undecided"),
+            VertexAssignment::False => write!(f, "false"),
+            VertexAssignment::True => write!(f, "true"),
         }
     }
 }
@@ -61,21 +61,21 @@ impl<V: Hash + Eq + PartialEq + Clone> Edge<V> {
 #[derive(Clone, Debug)]
 pub enum Message<V: Hash + Eq + PartialEq + Clone> {
     /// Send from a worker that needs the final assignment of `vertex` but is not the owner of the vertex.
-    REQUEST {
+    Request {
         vertex: V,
         depth: u32,
         worker_id: WorkerId,
     },
     /// Send from the owner of `vertex` to all workers that have requested the final assignment of `vertex`
-    ANSWER {
+    Answer {
         vertex: V,
         assignment: VertexAssignment,
     },
-    TOKEN(MsgToken),
+    Token(MsgToken),
     /// Release component/negation-edges of `depth` depth
-    RELEASE(usize),
+    Release(usize),
     /// Terminate the worker
-    TERMINATE,
+    Terminate,
 }
 
 #[derive(Clone, Debug, PartialOrd, Ord, Eq, PartialEq)]

--- a/atl-checker/src/algorithms/certain_zero/common.rs
+++ b/atl-checker/src/algorithms/certain_zero/common.rs
@@ -32,7 +32,7 @@ impl Display for VertexAssignment {
 impl<V: Hash + Eq + PartialEq + Clone> Edge<V> {
     /// Returns true if this is a hyper edge
     pub fn is_hyper(&self) -> bool {
-        matches!(self, Edge::HYPER(_))
+        matches!(self, Edge::Hyper(_))
     }
 
     /// Returns true if this is a negation edge
@@ -43,16 +43,16 @@ impl<V: Hash + Eq + PartialEq + Clone> Edge<V> {
     /// Returns the source vertex of this edge
     pub fn source(&self) -> &V {
         match self {
-            Edge::HYPER(e) => &e.source,
-            Edge::NEGATION(e) => &e.source,
+            Edge::Hyper(e) => &e.source,
+            Edge::Negation(e) => &e.source,
         }
     }
 
     /// Returns the targets vertices of this edge
     pub fn targets(&self) -> Vec<&V> {
         match self {
-            Edge::HYPER(e) => e.targets.iter().collect(),
-            Edge::NEGATION(e) => vec![&e.target],
+            Edge::Hyper(e) => e.targets.iter().collect(),
+            Edge::Negation(e) => vec![&e.target],
         }
     }
 }

--- a/atl-checker/src/algorithms/certain_zero/mod.rs
+++ b/atl-checker/src/algorithms/certain_zero/mod.rs
@@ -387,10 +387,10 @@ impl<
     /// Process an edge by delegating depending on edge type
     fn process_edge(&mut self, edge: Edge<V>) {
         match edge {
-            Edge::HYPER(e) => {
+            Edge::Hyper(e) => {
                 self.process_hyper_edge(e);
             }
-            Edge::NEGATION(e) => {
+            Edge::Negation(e) => {
                 self.process_negation_edge(e);
             }
         }
@@ -517,7 +517,7 @@ impl<
 
         // Line 4
         if any_target {
-            self.delete_edge(Edge::HYPER(edge));
+            self.delete_edge(Edge::Hyper(edge));
             return;
         }
 
@@ -528,12 +528,12 @@ impl<
                 Some(VertexAssignment::UNDECIDED) => {
                     // UNDECIDED
                     // Line 7
-                    self.add_depend(target, Edge::HYPER(edge.clone()));
+                    self.add_depend(target, Edge::Hyper(edge.clone()));
                 }
                 None => {
                     // UNEXPLORED
                     // Line 7
-                    self.add_depend(target, Edge::HYPER(edge.clone()));
+                    self.add_depend(target, Edge::Hyper(edge.clone()));
                     // Line 8
                     self.explore(target);
                 }
@@ -581,7 +581,7 @@ impl<
                 // UNEXPLORED
                 // Line 6
                 trace!(?edge, assignment = "UNEXPLORED", "processing negation edge");
-                self.add_depend(&edge.target, Edge::NEGATION(edge.clone()));
+                self.add_depend(&edge.target, Edge::Negation(edge.clone()));
                 self.queue_unsafe_negation(edge.clone());
                 self.explore(&edge.target);
             }
@@ -596,7 +596,7 @@ impl<
                         // must be from another branch of the EDG. Hence, we add this edge as an
                         // unsafe dependency
                         trace!(?edge, assignment = ?VertexAssignment::UNDECIDED, "processing negation edge");
-                        self.add_depend(&edge.target, Edge::NEGATION(edge.clone()));
+                        self.add_depend(&edge.target, Edge::Negation(edge.clone()));
                         self.queue_unsafe_negation(edge.clone())
                     }
                 }
@@ -606,7 +606,7 @@ impl<
                 }
                 VertexAssignment::TRUE => {
                     trace!(?edge, assignment = ?VertexAssignment::TRUE, "processing negation edge");
-                    self.delete_edge(Edge::NEGATION(edge))
+                    self.delete_edge(Edge::Negation(edge))
                 }
             },
         }
@@ -760,16 +760,16 @@ impl<
 
         match edge {
             // Line 4-6
-            Edge::HYPER(ref edge) => {
+            Edge::Hyper(ref edge) => {
                 debug!(source = ?edge, targets = ?edge.targets, "remove hyper-edge as dependency");
                 for target in &edge.targets {
-                    self.remove_depend(target, Edge::HYPER(edge.clone()))
+                    self.remove_depend(target, Edge::Hyper(edge.clone()))
                 }
             }
             // Line 7-8
-            Edge::NEGATION(ref edge) => {
+            Edge::Negation(ref edge) => {
                 debug!(source = ?edge, target = ?edge.target, "remove negation-edge as dependency");
-                self.remove_depend(&edge.target, Edge::NEGATION(edge.clone()))
+                self.remove_depend(&edge.target, Edge::Negation(edge.clone()))
             }
         }
     }

--- a/atl-checker/src/algorithms/certain_zero/mod.rs
+++ b/atl-checker/src/algorithms/certain_zero/mod.rs
@@ -204,7 +204,7 @@ impl<
             deepest_component: max(msg.deepest_component, self.get_depth_of_deepest_component()),
         };
 
-        self.broker.send(successor, Message::TOKEN(token))
+        self.broker.send(successor, Message::Token(token))
     }
 
     pub fn run(&mut self) {
@@ -248,7 +248,7 @@ impl<
             match self.broker.receive() {
                 Ok(opt_msg) => match opt_msg {
                     Some(msg) => match msg {
-                        Message::TERMINATE => {
+                        Message::Terminate => {
                             emit_count!("worker received_termination");
 
                             self.running = false;
@@ -291,7 +291,7 @@ impl<
                 } => {
                     trace!("Late termination");
                     emit_count!("worker late_termination");
-                    self.broker.return_result(VertexAssignment::FALSE)
+                    self.broker.return_result(VertexAssignment::False)
                 }
                 // No one has seen safe tasks, but some workers have unsafe negation edges.
                 MsgToken {
@@ -340,7 +340,7 @@ impl<
         emit_count!("worker initiate_token_circulation");
         self.broker.send(
             (self.id + 1) % self.worker_count,
-            Message::TOKEN(MsgToken {
+            Message::Token(MsgToken {
                 token,
                 deepest_component: self.get_depth_of_deepest_component(),
             }),
@@ -360,17 +360,17 @@ impl<
             let _guard = span!(Level::TRACE, "worker receive message", worker_id = self.id);
             match msg {
                 // Alg 1, Line 8
-                Message::REQUEST {
+                Message::Request {
                     vertex,
                     depth,
                     worker_id,
                 } => self.process_request(&vertex, worker_id, depth),
                 // Alg 1, Line 9
-                Message::ANSWER { vertex, assignment } => self.process_answer(&vertex, assignment),
-                Message::RELEASE(depth) => {
+                Message::Answer { vertex, assignment } => self.process_answer(&vertex, assignment),
+                Message::Release(depth) => {
                     self.release_negations(depth);
                 }
-                Message::TOKEN(msg_token) => {
+                Message::Token(msg_token) => {
                     self.handle_incoming_token(msg_token);
                 }
                 _ => unreachable!(),
@@ -448,7 +448,7 @@ impl<
         emit_count!("worker explore_vertex");
         // Line 2
         self.assignment
-            .insert(vertex.clone(), VertexAssignment::UNDECIDED);
+            .insert(vertex.clone(), VertexAssignment::Undecided);
 
         // Line 3
         if self.is_owner(vertex) {
@@ -469,7 +469,7 @@ impl<
             if successors.is_empty() {
                 // Line 4
                 // The vertex has no outgoing edges, so we assign it false
-                self.final_assign(vertex, VertexAssignment::FALSE);
+                self.final_assign(vertex, VertexAssignment::False);
             } else {
                 // Line 5
                 // Queue the new edges
@@ -480,7 +480,7 @@ impl<
             // The vertex is owned by another worker, so we send a request
             self.broker.send(
                 self.vertex_owner(vertex),
-                Message::REQUEST {
+                Message::Request {
                     vertex: vertex.clone(),
                     depth: *self.depth.get(vertex).unwrap_or(&0),
                     worker_id: self.id,
@@ -499,12 +499,12 @@ impl<
         let all_final = edge.targets.iter().all(|target| {
             self.assignment
                 .get(target)
-                .map_or(false, |f| matches!(f, VertexAssignment::TRUE))
+                .map_or(false, |f| matches!(f, VertexAssignment::True))
         });
 
         // Line 3
         if all_final {
-            self.final_assign(&edge.source, VertexAssignment::TRUE);
+            self.final_assign(&edge.source, VertexAssignment::True);
             return;
         }
 
@@ -512,7 +512,7 @@ impl<
         let any_target = edge.targets.iter().any(|target| {
             self.assignment
                 .get(target)
-                .map_or(false, |f| matches!(f, VertexAssignment::FALSE))
+                .map_or(false, |f| matches!(f, VertexAssignment::False))
         });
 
         // Line 4
@@ -525,7 +525,7 @@ impl<
         for target in &edge.targets {
             // Line 5 condition
             match self.assignment.get(&target) {
-                Some(VertexAssignment::UNDECIDED) => {
+                Some(VertexAssignment::Undecided) => {
                     // UNDECIDED
                     // Line 7
                     self.add_depend(target, Edge::Hyper(edge.clone()));
@@ -586,26 +586,26 @@ impl<
                 self.explore(&edge.target);
             }
             Some(assignment) => match assignment {
-                VertexAssignment::UNDECIDED => {
+                VertexAssignment::Undecided => {
                     if self.only_unsafe_left {
                         // This is a released negation edge
-                        trace!(?edge, assignment = ?VertexAssignment::UNDECIDED, "processing released negation edge");
-                        self.final_assign(&edge.source, VertexAssignment::TRUE)
+                        trace!(?edge, assignment = ?VertexAssignment::Undecided, "processing released negation edge");
+                        self.final_assign(&edge.source, VertexAssignment::True)
                     } else {
                         // We haven't released any negation edges yet, so the undecided assignment
                         // must be from another branch of the EDG. Hence, we add this edge as an
                         // unsafe dependency
-                        trace!(?edge, assignment = ?VertexAssignment::UNDECIDED, "processing negation edge");
+                        trace!(?edge, assignment = ?VertexAssignment::Undecided, "processing negation edge");
                         self.add_depend(&edge.target, Edge::Negation(edge.clone()));
                         self.queue_unsafe_negation(edge.clone())
                     }
                 }
-                VertexAssignment::FALSE => {
-                    trace!(?edge, assignment = ?VertexAssignment::FALSE, "processing negation edge");
-                    self.final_assign(&edge.source, VertexAssignment::TRUE)
+                VertexAssignment::False => {
+                    trace!(?edge, assignment = ?VertexAssignment::False, "processing negation edge");
+                    self.final_assign(&edge.source, VertexAssignment::True)
                 }
-                VertexAssignment::TRUE => {
-                    trace!(?edge, assignment = ?VertexAssignment::TRUE, "processing negation edge");
+                VertexAssignment::True => {
+                    trace!(?edge, assignment = ?VertexAssignment::True, "processing negation edge");
                     self.delete_edge(Edge::Negation(edge))
                 }
             },
@@ -653,7 +653,7 @@ impl<
             if assignment.is_certain() {
                 self.broker.send(
                     requester,
-                    Message::ANSWER {
+                    Message::Answer {
                         vertex: vertex.clone(),
                         assignment: *assignment,
                     },
@@ -714,7 +714,7 @@ impl<
                 for worker_id in interested {
                     self.broker.send(
                         *worker_id,
-                        Message::ANSWER {
+                        Message::Answer {
                             vertex: vertex.clone(),
                             assignment,
                         },
@@ -752,10 +752,10 @@ impl<
         {
             trace!(
                 ?source,
-                assignment = ?VertexAssignment::FALSE,
+                assignment = ?VertexAssignment::False,
                 "no more successors, final assignment is FALSE"
             );
-            self.final_assign(source, VertexAssignment::FALSE);
+            self.final_assign(source, VertexAssignment::False);
         }
 
         match edge {
@@ -853,7 +853,7 @@ mod test {
         simple_edg![
             A => -> {};
         ];
-        edg_assert!(A, TRUE);
+        edg_assert!(A, True);
     }
 
     #[test]
@@ -861,7 +861,7 @@ mod test {
         simple_edg![
             A => ;
         ];
-        edg_assert!(A, FALSE);
+        edg_assert!(A, False);
     }
 
     #[test]
@@ -872,10 +872,10 @@ mod test {
             C => .> D;
             D => -> {};
         ];
-        edg_assert!(A, TRUE);
-        edg_assert!(B, FALSE);
-        edg_assert!(C, FALSE);
-        edg_assert!(D, TRUE);
+        edg_assert!(A, True);
+        edg_assert!(B, False);
+        edg_assert!(C, False);
+        edg_assert!(D, True);
     }
 
     #[test]
@@ -887,11 +887,11 @@ mod test {
             D => -> {} -> {C};
             E => .> D;
         ];
-        edg_assert!(A, TRUE);
-        edg_assert!(B, TRUE);
-        edg_assert!(C, TRUE);
-        edg_assert!(D, TRUE);
-        edg_assert!(E, FALSE);
+        edg_assert!(A, True);
+        edg_assert!(B, True);
+        edg_assert!(C, True);
+        edg_assert!(D, True);
+        edg_assert!(E, False);
     }
 
     #[test]
@@ -907,15 +907,15 @@ mod test {
             H => -> {I};
             I => ;
         ];
-        edg_assert!(A, TRUE);
-        edg_assert!(B, TRUE);
-        edg_assert!(C, TRUE);
-        edg_assert!(D, TRUE);
-        edg_assert!(E, TRUE);
-        edg_assert!(F, TRUE);
-        edg_assert!(G, FALSE);
-        edg_assert!(H, FALSE);
-        edg_assert!(I, FALSE);
+        edg_assert!(A, True);
+        edg_assert!(B, True);
+        edg_assert!(C, True);
+        edg_assert!(D, True);
+        edg_assert!(E, True);
+        edg_assert!(F, True);
+        edg_assert!(G, False);
+        edg_assert!(H, False);
+        edg_assert!(I, False);
     }
 
     #[test]
@@ -926,10 +926,10 @@ mod test {
             C => ;
             D => -> {};
         ];
-        edg_assert!(A, TRUE);
-        edg_assert!(B, TRUE);
-        edg_assert!(C, FALSE);
-        edg_assert!(D, TRUE);
+        edg_assert!(A, True);
+        edg_assert!(B, True);
+        edg_assert!(C, False);
+        edg_assert!(D, True);
     }
 
     #[test]
@@ -939,9 +939,9 @@ mod test {
             B => -> {C};
             C => -> {B};
         ];
-        edg_assert!(A, FALSE);
-        edg_assert!(B, FALSE);
-        edg_assert!(C, FALSE);
+        edg_assert!(A, False);
+        edg_assert!(B, False);
+        edg_assert!(C, False);
     }
 
     #[test]
@@ -951,9 +951,9 @@ mod test {
             B => ;
             C => ;
         ];
-        edg_assert!(A, FALSE);
-        edg_assert!(B, FALSE);
-        edg_assert!(C, FALSE);
+        edg_assert!(A, False);
+        edg_assert!(B, False);
+        edg_assert!(C, False);
     }
 
     #[test]
@@ -964,10 +964,10 @@ mod test {
             C => -> {D};
             D => -> {};
         ];
-        edg_assert!(A, FALSE);
-        edg_assert!(B, FALSE);
-        edg_assert!(C, TRUE);
-        edg_assert!(D, TRUE);
+        edg_assert!(A, False);
+        edg_assert!(B, False);
+        edg_assert!(C, True);
+        edg_assert!(D, True);
     }
 
     #[test]
@@ -978,10 +978,10 @@ mod test {
             C => -> {B};
             D => -> {C} -> {};
         ];
-        edg_assert!(A, TRUE);
-        edg_assert!(B, TRUE);
-        edg_assert!(C, TRUE);
-        edg_assert!(D, TRUE);
+        edg_assert!(A, True);
+        edg_assert!(B, True);
+        edg_assert!(C, True);
+        edg_assert!(D, True);
     }
 
     #[test]
@@ -990,8 +990,8 @@ mod test {
             A => .> B;
             B => -> {};
         ];
-        edg_assert!(A, FALSE);
-        edg_assert!(B, TRUE);
+        edg_assert!(A, False);
+        edg_assert!(B, True);
     }
 
     #[test]
@@ -1003,11 +1003,11 @@ mod test {
             D => -> {E};
             E => -> {D};
         ];
-        edg_assert!(A, FALSE);
-        edg_assert!(B, TRUE);
-        edg_assert!(C, TRUE);
-        edg_assert!(D, FALSE);
-        edg_assert!(E, FALSE);
+        edg_assert!(A, False);
+        edg_assert!(B, True);
+        edg_assert!(C, True);
+        edg_assert!(D, False);
+        edg_assert!(E, False);
     }
 
     #[test]
@@ -1018,10 +1018,10 @@ mod test {
             C => -> {D};
             D => ;
         ];
-        edg_assert!(A, TRUE);
-        edg_assert!(B, TRUE);
-        edg_assert!(C, FALSE);
-        edg_assert!(D, FALSE);
+        edg_assert!(A, True);
+        edg_assert!(B, True);
+        edg_assert!(C, False);
+        edg_assert!(D, False);
     }
 
     #[test]
@@ -1030,8 +1030,8 @@ mod test {
             A => .> B;
             B => -> {B};
         ];
-        edg_assert!(A, TRUE);
-        edg_assert!(B, FALSE);
+        edg_assert!(A, True);
+        edg_assert!(B, False);
     }
 
     #[test]
@@ -1044,12 +1044,12 @@ mod test {
             E => .> F;
             F => -> {F};
         ];
-        edg_assert!(A, TRUE);
-        edg_assert!(B, FALSE);
-        edg_assert!(C, TRUE);
-        edg_assert!(D, FALSE);
-        edg_assert!(E, TRUE);
-        edg_assert!(F, FALSE);
+        edg_assert!(A, True);
+        edg_assert!(B, False);
+        edg_assert!(C, True);
+        edg_assert!(D, False);
+        edg_assert!(E, True);
+        edg_assert!(F, False);
     }
 
     #[test]
@@ -1069,12 +1069,12 @@ mod test {
             J => -> {K};
             K => -> {};
         ];
-        edg_assert!(A, TRUE);
-        edg_assert!(B, FALSE);
-        edg_assert!(C, FALSE);
-        edg_assert!(D, FALSE);
-        edg_assert!(E, TRUE);
-        edg_assert!(F, TRUE);
-        edg_assert!(G, TRUE);
+        edg_assert!(A, True);
+        edg_assert!(B, False);
+        edg_assert!(C, False);
+        edg_assert!(D, False);
+        edg_assert!(E, True);
+        edg_assert!(F, True);
+        edg_assert!(G, True);
     }
 }

--- a/atl-checker/src/algorithms/certain_zero/search_strategy/bfs.rs
+++ b/atl-checker/src/algorithms/certain_zero/search_strategy/bfs.rs
@@ -23,12 +23,6 @@ impl<V: Vertex> Default for BreadthFirstSearch<V> {
     }
 }
 
-impl<V: Vertex> Default for BreadthFirstSearch<V> {
-    fn default() -> Self {
-        BreadthFirstSearch::new()
-    }
-}
-
 impl<V: Vertex> SearchStrategy<V> for BreadthFirstSearch<V> {
     fn next(&mut self) -> Option<Edge<V>> {
         self.queue.pop_front()

--- a/atl-checker/src/algorithms/certain_zero/search_strategy/bfs.rs
+++ b/atl-checker/src/algorithms/certain_zero/search_strategy/bfs.rs
@@ -23,6 +23,12 @@ impl<V: Vertex> Default for BreadthFirstSearch<V> {
     }
 }
 
+impl<V: Vertex> Default for BreadthFirstSearch<V> {
+    fn default() -> Self {
+        BreadthFirstSearch::new()
+    }
+}
+
 impl<V: Vertex> SearchStrategy<V> for BreadthFirstSearch<V> {
     fn next(&mut self) -> Option<Edge<V>> {
         self.queue.pop_front()

--- a/atl-checker/src/algorithms/certain_zero/search_strategy/bfs.rs
+++ b/atl-checker/src/algorithms/certain_zero/search_strategy/bfs.rs
@@ -17,6 +17,12 @@ impl<V: Vertex> BreadthFirstSearch<V> {
     }
 }
 
+impl<V: Vertex> Default for BreadthFirstSearch<V> {
+    fn default() -> Self {
+        BreadthFirstSearch::new()
+    }
+}
+
 impl<V: Vertex> SearchStrategy<V> for BreadthFirstSearch<V> {
     fn next(&mut self) -> Option<Edge<V>> {
         self.queue.pop_front()

--- a/atl-checker/src/algorithms/certain_zero/search_strategy/dependency_heuristic.rs
+++ b/atl-checker/src/algorithms/certain_zero/search_strategy/dependency_heuristic.rs
@@ -74,7 +74,7 @@ impl<V: Vertex> SearchStrategy<V> for DependencyHeuristicSearch<V> {
             // For each target, increase their priority since we found a new edge,
             // that depends on it
             match &edge {
-                Edge::HYPER(edge) => {
+                Edge::Hyper(edge) => {
                     for target in &edge.targets {
                         let dependency = self
                             .dependencies
@@ -83,7 +83,7 @@ impl<V: Vertex> SearchStrategy<V> for DependencyHeuristicSearch<V> {
                         dependency.rank += 1;
                     }
                 }
-                Edge::NEGATION(edge) => {
+                Edge::Negation(edge) => {
                     let dependency = self
                         .dependencies
                         .entry(edge.target.clone())
@@ -98,7 +98,7 @@ impl<V: Vertex> SearchStrategy<V> for DependencyHeuristicSearch<V> {
 
     fn queue_released_edges(&mut self, edges: Vec<NegationEdge<V>>) {
         for edge in edges {
-            self.queue(Edge::NEGATION(edge));
+            self.queue(Edge::Negation(edge));
         }
     }
 

--- a/atl-checker/src/algorithms/certain_zero/search_strategy/dfs.rs
+++ b/atl-checker/src/algorithms/certain_zero/search_strategy/dfs.rs
@@ -12,6 +12,12 @@ impl<V: Vertex> DepthFirstSearch<V> {
     }
 }
 
+impl<V: Vertex> Default for DepthFirstSearch<V> {
+    fn default() -> Self {
+        DepthFirstSearch::new()
+    }
+}
+
 impl<V: Vertex> SearchStrategy<V> for DepthFirstSearch<V> {
     fn next(&mut self) -> Option<Edge<V>> {
         self.stack.pop()

--- a/atl-checker/src/algorithms/certain_zero/search_strategy/dfs.rs
+++ b/atl-checker/src/algorithms/certain_zero/search_strategy/dfs.rs
@@ -18,6 +18,12 @@ impl<V: Vertex> Default for DepthFirstSearch<V> {
     }
 }
 
+impl<V: Vertex> Default for DepthFirstSearch<V> {
+    fn default() -> Self {
+        DepthFirstSearch::new()
+    }
+}
+
 impl<V: Vertex> SearchStrategy<V> for DepthFirstSearch<V> {
     fn next(&mut self) -> Option<Edge<V>> {
         self.stack.pop()

--- a/atl-checker/src/algorithms/certain_zero/search_strategy/dfs.rs
+++ b/atl-checker/src/algorithms/certain_zero/search_strategy/dfs.rs
@@ -18,12 +18,6 @@ impl<V: Vertex> Default for DepthFirstSearch<V> {
     }
 }
 
-impl<V: Vertex> Default for DepthFirstSearch<V> {
-    fn default() -> Self {
-        DepthFirstSearch::new()
-    }
-}
-
 impl<V: Vertex> SearchStrategy<V> for DepthFirstSearch<V> {
     fn next(&mut self) -> Option<Edge<V>> {
         self.stack.pop()

--- a/atl-checker/src/algorithms/certain_zero/search_strategy/mod.rs
+++ b/atl-checker/src/algorithms/certain_zero/search_strategy/mod.rs
@@ -18,7 +18,7 @@ pub trait SearchStrategy<V: Vertex> {
     /// Queue a set of previously unsafe negation edges
     fn queue_released_edges(&mut self, edges: Vec<NegationEdge<V>>) {
         let mut edges = edges;
-        self.queue_new_edges(edges.drain(..).map(Edge::NEGATION).collect())
+        self.queue_new_edges(edges.drain(..).map(Edge::Negation).collect())
     }
 
     /// Requeue an edge because one of its targets was assigned a certain value

--- a/atl-checker/src/algorithms/solve_set.rs
+++ b/atl-checker/src/algorithms/solve_set.rs
@@ -194,9 +194,9 @@ fn find_solve_set_rec<G: ExtendedDependencyGraph<V>, V: Vertex>(
                 "We should not be recalculating certain answers"
             );
             if solve_set.len() > prev_assign.len() {
-                assignments.insert(vertex.clone(), solve_set.clone());
+                assignments.insert(vertex, solve_set.clone());
             } else {
-                assignments.insert(vertex.clone(), prev_assign);
+                assignments.insert(vertex, prev_assign);
             }
         } else {
             // No uncertainty in this solve set, just update
@@ -205,7 +205,7 @@ fn find_solve_set_rec<G: ExtendedDependencyGraph<V>, V: Vertex>(
 
         solve_set
     } else {
-        prev_assignment.unwrap().clone()
+        prev_assignment.unwrap()
     }
 }
 

--- a/atl-checker/src/algorithms/solve_set.rs
+++ b/atl-checker/src/algorithms/solve_set.rs
@@ -36,6 +36,14 @@ impl<V: Hash + Eq + PartialEq + Clone + Debug> SolveSetAssignment<V> {
         }
     }
 
+    pub fn is_empty(&self) -> bool {
+        match self {
+            SolveSetAssignment::BeingCalculated => panic!("Solve set is being calculated"),
+            SolveSetAssignment::True(vertices) => vertices.is_empty(),
+            SolveSetAssignment::False(vertices, _) => vertices.is_empty(),
+        }
+    }
+
     /// Get the number of elements in the solve set, negative if SolveSetAssignment::False.
     /// The sign is an implementation detail, so this function is mainly for debugging.
     #[allow(dead_code)]
@@ -82,6 +90,7 @@ pub fn minimum_solve_set<G: ExtendedDependencyGraph<V>, V: Vertex>(
 
 /// Recursive part of minimum_solve_set algorithm. Here we find the solve set of the given
 /// vertex by exploring all its edges.
+#[allow(clippy::unnecessary_unwrap)]
 fn find_solve_set_rec<G: ExtendedDependencyGraph<V>, V: Vertex>(
     edg: &G,
     vertex: V,
@@ -200,7 +209,7 @@ fn find_solve_set_rec<G: ExtendedDependencyGraph<V>, V: Vertex>(
             }
         } else {
             // No uncertainty in this solve set, just update
-            assignments.insert(vertex.clone(), solve_set.clone());
+            assignments.insert(vertex, solve_set.clone());
         }
 
         solve_set

--- a/atl-checker/src/algorithms/solve_set.rs
+++ b/atl-checker/src/algorithms/solve_set.rs
@@ -110,7 +110,7 @@ fn find_solve_set_rec<G: ExtendedDependencyGraph<V>, V: Vertex>(
 
         for edge in edges {
             match edge {
-                Edge::HYPER(hyper) => {
+                Edge::Hyper(hyper) => {
                     // In the world of hyper-edges, we can short circuit when we find one edge,
                     // where the target is assigned false. So this is the inverse of before:
                     // We hope to find the edges that makes the assignment false with the fewest
@@ -154,7 +154,7 @@ fn find_solve_set_rec<G: ExtendedDependencyGraph<V>, V: Vertex>(
                         }
                     }
                 }
-                Edge::NEGATION(negation) => {
+                Edge::Negation(negation) => {
                     // When target is true, source if false, and vice versa. But the set of
                     // vertices that need to be checked remain the same
                     match find_solve_set_rec(edg, negation.target, assignments) {

--- a/atl-checker/src/analyse.rs
+++ b/atl-checker/src/analyse.rs
@@ -1,7 +1,6 @@
 use crate::algorithms::solve_set::{minimum_solve_set, SolveSetAssignment};
 use crate::atl::Phi;
-use crate::edg::atlcgsedg::ATLVertex;
-use crate::edg::{Edge, ExtendedDependencyGraph};
+use crate::edg::{AtlVertex, Edge, ExtendedDependencyGraph};
 
 #[derive(Serialize, Deserialize)]
 #[serde(tag = "type")]
@@ -84,12 +83,12 @@ pub struct PhiStats {
 
 /// Analyses the vertices of an EDG starting from the given root, and returns a Vec of data
 /// describing each vertex with different data depending of the vertex' ATL formula.
-pub fn analyse<G: ExtendedDependencyGraph<ATLVertex>>(edg: &G, root: ATLVertex) -> Vec<VertexData> {
+pub fn analyse<G: ExtendedDependencyGraph<AtlVertex>>(edg: &G, root: AtlVertex) -> Vec<VertexData> {
     let mss = minimum_solve_set(edg, root);
     let mut data = vec![];
     for (v, mssa) in &mss {
         match v {
-            ATLVertex::FULL { formula, .. } => match formula.as_ref() {
+            AtlVertex::Full { formula, .. } => match formula.as_ref() {
                 Phi::Proposition(..) => data.push(VertexData::Proposition {
                     // Propositions are assigned 1 in certain zero iff they have a positive signed
                     // solve set
@@ -241,7 +240,7 @@ pub fn analyse<G: ExtendedDependencyGraph<ATLVertex>>(edg: &G, root: ATLVertex) 
                 }
                 _ => {}
             },
-            ATLVertex::PARTIAL { .. } => data.push(VertexData::Partial {
+            AtlVertex::Partial { .. } => data.push(VertexData::Partial {
                 stats: phi_stats(mssa, v),
                 target_stats: edg
                     .succ(v)
@@ -262,7 +261,7 @@ pub fn analyse<G: ExtendedDependencyGraph<ATLVertex>>(edg: &G, root: ATLVertex) 
 }
 
 /// Returns statistics about a given vertex
-fn phi_stats(mssa: &SolveSetAssignment<ATLVertex>, v: &ATLVertex) -> PhiStats {
+fn phi_stats(mssa: &SolveSetAssignment<AtlVertex>, v: &AtlVertex) -> PhiStats {
     let phi = v.formula();
     PhiStats {
         solve_set_size: mssa.len() as u32,

--- a/atl-checker/src/analyse.rs
+++ b/atl-checker/src/analyse.rs
@@ -115,7 +115,7 @@ pub fn analyse<G: ExtendedDependencyGraph<AtlVertex>>(edg: &G, root: AtlVertex) 
                 Phi::And(..) => data.push(VertexData::And {
                     stats: phi_stats(mssa, v),
                     // And-formulae only have one hyper-edge with multiple targets
-                    target_stats: if let Edge::Hyper(e) = edg.succ(v).get(0) {
+                    target_stats: if let Edge::Hyper(e) = edg.succ(v).get(0).unwrap() {
                         e.targets.iter().map(|t| phi_stats(mssa, t)).collect()
                     } else {
                         unreachable!()
@@ -125,7 +125,7 @@ pub fn analyse<G: ExtendedDependencyGraph<AtlVertex>>(edg: &G, root: AtlVertex) 
                     player_count: players.len() as u32,
                     stats: phi_stats(mssa, v),
                     // And-formulae only have one hyper-edge with multiple targets
-                    target_stats: if let Edge::Hyper(e) = edg.succ(v).get(0) {
+                    target_stats: if let Edge::Hyper(e) = edg.succ(v).get(0).unwrap() {
                         e.targets.iter().map(|t| phi_stats(mssa, t)).collect()
                     } else {
                         unreachable!()

--- a/atl-checker/src/analyse.rs
+++ b/atl-checker/src/analyse.rs
@@ -115,7 +115,7 @@ pub fn analyse<G: ExtendedDependencyGraph<AtlVertex>>(edg: &G, root: AtlVertex) 
                 Phi::And(..) => data.push(VertexData::And {
                     stats: phi_stats(mssa, v),
                     // And-formulae only have one hyper-edge with multiple targets
-                    target_stats: if let Edge::Hyper(e) = edg.succ(v).get(0).unwrap() {
+                    target_stats: if let Edge::Hyper(e) = edg.succ(v).get(0) {
                         e.targets.iter().map(|t| phi_stats(mssa, t)).collect()
                     } else {
                         unreachable!()
@@ -125,7 +125,7 @@ pub fn analyse<G: ExtendedDependencyGraph<AtlVertex>>(edg: &G, root: AtlVertex) 
                     player_count: players.len() as u32,
                     stats: phi_stats(mssa, v),
                     // And-formulae only have one hyper-edge with multiple targets
-                    target_stats: if let Edge::Hyper(e) = edg.succ(v).get(0).unwrap() {
+                    target_stats: if let Edge::Hyper(e) = edg.succ(v).get(0) {
                         e.targets.iter().map(|t| phi_stats(mssa, t)).collect()
                     } else {
                         unreachable!()

--- a/atl-checker/src/analyse.rs
+++ b/atl-checker/src/analyse.rs
@@ -1,6 +1,7 @@
 use crate::algorithms::solve_set::{minimum_solve_set, SolveSetAssignment};
 use crate::atl::Phi;
-use crate::edg::{AtlVertex, Edge, ExtendedDependencyGraph};
+use crate::edg::atlcgsedg::AtlVertex;
+use crate::edg::{Edge, ExtendedDependencyGraph};
 
 #[derive(Serialize, Deserialize)]
 #[serde(tag = "type")]

--- a/atl-checker/src/analyse.rs
+++ b/atl-checker/src/analyse.rs
@@ -105,7 +105,7 @@ pub fn analyse<G: ExtendedDependencyGraph<ATLVertex>>(edg: &G, root: ATLVertex) 
                         .iter()
                         .map(|e| {
                             // Or-formula have multiple hyper-edges with one target
-                            if let Edge::HYPER(e) = e {
+                            if let Edge::Hyper(e) = e {
                                 phi_stats(mssa, &e.targets.get(0).unwrap())
                             } else {
                                 unreachable!()
@@ -116,7 +116,7 @@ pub fn analyse<G: ExtendedDependencyGraph<ATLVertex>>(edg: &G, root: ATLVertex) 
                 Phi::And(..) => data.push(VertexData::And {
                     stats: phi_stats(mssa, v),
                     // And-formulae only have one hyper-edge with multiple targets
-                    target_stats: if let Edge::HYPER(e) = edg.succ(v).iter().next().unwrap() {
+                    target_stats: if let Edge::Hyper(e) = edg.succ(v).iter().next().unwrap() {
                         e.targets.iter().map(|t| phi_stats(mssa, t)).collect()
                     } else {
                         unreachable!()
@@ -126,7 +126,7 @@ pub fn analyse<G: ExtendedDependencyGraph<ATLVertex>>(edg: &G, root: ATLVertex) 
                     player_count: players.len() as u32,
                     stats: phi_stats(mssa, v),
                     // And-formulae only have one hyper-edge with multiple targets
-                    target_stats: if let Edge::HYPER(e) = edg.succ(v).iter().next().unwrap() {
+                    target_stats: if let Edge::Hyper(e) = edg.succ(v).iter().next().unwrap() {
                         e.targets.iter().map(|t| phi_stats(mssa, t)).collect()
                     } else {
                         unreachable!()
@@ -248,7 +248,7 @@ pub fn analyse<G: ExtendedDependencyGraph<ATLVertex>>(edg: &G, root: ATLVertex) 
                     .iter()
                     .map(|e| {
                         // Partial vertices have multiple hyper-edges with one target
-                        if let Edge::HYPER(e) = e {
+                        if let Edge::Hyper(e) = e {
                             phi_stats(mssa, &e.targets.get(0).unwrap())
                         } else {
                             unreachable!()

--- a/atl-checker/src/analyse.rs
+++ b/atl-checker/src/analyse.rs
@@ -115,7 +115,7 @@ pub fn analyse<G: ExtendedDependencyGraph<AtlVertex>>(edg: &G, root: AtlVertex) 
                 Phi::And(..) => data.push(VertexData::And {
                     stats: phi_stats(mssa, v),
                     // And-formulae only have one hyper-edge with multiple targets
-                    target_stats: if let Edge::Hyper(e) = edg.succ(v).iter().next().unwrap() {
+                    target_stats: if let Edge::Hyper(e) = edg.succ(v).get(0) {
                         e.targets.iter().map(|t| phi_stats(mssa, t)).collect()
                     } else {
                         unreachable!()
@@ -125,7 +125,7 @@ pub fn analyse<G: ExtendedDependencyGraph<AtlVertex>>(edg: &G, root: AtlVertex) 
                     player_count: players.len() as u32,
                     stats: phi_stats(mssa, v),
                     // And-formulae only have one hyper-edge with multiple targets
-                    target_stats: if let Edge::Hyper(e) = edg.succ(v).iter().next().unwrap() {
+                    target_stats: if let Edge::Hyper(e) = edg.succ(v).get(0) {
                         e.targets.iter().map(|t| phi_stats(mssa, t)).collect()
                     } else {
                         unreachable!()

--- a/atl-checker/src/atl/parser.rs
+++ b/atl-checker/src/atl/parser.rs
@@ -199,9 +199,7 @@ fn despite_invariant<A: AtlExpressionParser>(expr_parser: &A) -> Parser<u8, Phi>
 
 /// Parses a proposition using the given [ATLExpressionParser].
 fn proposition<A: AtlExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
-    expr_parser
-        .proposition_parser()
-        .map(|id| Phi::Proposition(id))
+    expr_parser.proposition_parser().map(Phi::Proposition)
 }
 
 /// Parses a negated ATL formula

--- a/atl-checker/src/atl/parser.rs
+++ b/atl-checker/src/atl/parser.rs
@@ -268,7 +268,7 @@ mod test {
         until, ATLExpressionParser,
     };
     use crate::atl::{parse_phi, Phi};
-    use crate::game_structure::lcgs::ir::intermediate::IntermediateLCGS;
+    use crate::game_structure::lcgs::ir::intermediate::IntermediateLcgs;
     use crate::game_structure::lcgs::parse::parse_lcgs;
     use crate::game_structure::{Player, Proposition};
 
@@ -750,7 +750,7 @@ mod test {
             [wait] 1;
         endtemplate
         ";
-        let lcgs = IntermediateLCGS::create(parse_lcgs(lcgs_program).unwrap()).unwrap();
+        let lcgs = IntermediateLcgs::create(parse_lcgs(lcgs_program).unwrap()).unwrap();
 
         let atl_formula = "<<p1>>";
         let phi = enforce_players(&lcgs).parse(&atl_formula.as_bytes());
@@ -767,7 +767,7 @@ mod test {
             [wait] 1;
         endtemplate
         ";
-        let lcgs = IntermediateLCGS::create(parse_lcgs(lcgs_program).unwrap()).unwrap();
+        let lcgs = IntermediateLcgs::create(parse_lcgs(lcgs_program).unwrap()).unwrap();
 
         let atl_formula = "<<p1>> F true";
         let phi = parse_phi(&lcgs, &atl_formula);
@@ -790,7 +790,7 @@ mod test {
             [wait] 1;
         endtemplate
         ";
-        let lcgs = IntermediateLCGS::create(parse_lcgs(lcgs_program).unwrap()).unwrap();
+        let lcgs = IntermediateLcgs::create(parse_lcgs(lcgs_program).unwrap()).unwrap();
 
         let atl_formula = "<<>> F test";
         let phi = parse_phi(&lcgs, &atl_formula);
@@ -814,7 +814,7 @@ mod test {
             [wait] 1;
         endtemplate
         ";
-        let lcgs = IntermediateLCGS::create(parse_lcgs(lcgs_program).unwrap()).unwrap();
+        let lcgs = IntermediateLcgs::create(parse_lcgs(lcgs_program).unwrap()).unwrap();
 
         let atl_formula = "<<p1>> F p1.test";
         let phi = parse_phi(&lcgs, &atl_formula);

--- a/atl-checker/src/atl/parser.rs
+++ b/atl-checker/src/atl/parser.rs
@@ -8,7 +8,7 @@ use super::Phi;
 use crate::game_structure::{Player, Proposition};
 
 /// Parse an ATL formula
-pub fn parse_phi<'a, 'b: 'a, A: ATLExpressionParser>(
+pub fn parse_phi<'a, 'b: 'a, A: AtlExpressionParser>(
     expr_parser: &'b A,
     input: &'a str,
 ) -> Result<Phi, String> {
@@ -21,7 +21,7 @@ pub fn parse_phi<'a, 'b: 'a, A: ATLExpressionParser>(
 /// Allows a CGS model to define custom player and proposition expressions. For instance,
 /// in LCGS we want to be able to write "p2" as a player and "p2.alive" as a proposition, while
 /// in json, players and propositions are numbers.
-pub trait ATLExpressionParser {
+pub trait AtlExpressionParser {
     /// A parser that parses a player name
     fn player_parser(&self) -> Parser<u8, Player>;
     /// A parser that parses a proposition name
@@ -37,7 +37,7 @@ fn ws<'a>() -> Parser<'a, u8, ()> {
 /// Normally we make recursive parsers with the `call(phi)` that wraps a parser with lazy
 /// invocation. But the `call` method does not allow us to pass our converter. So we
 /// make our own lazy parser.
-fn lazy<'a, A: ATLExpressionParser, P: Fn(&'a A) -> Parser<u8, Phi>>(
+fn lazy<'a, A: AtlExpressionParser, P: Fn(&'a A) -> Parser<u8, Phi>>(
     parser: &'a P,
     expr_parser: &'a A,
 ) -> Parser<'a, u8, Phi> {
@@ -45,7 +45,7 @@ fn lazy<'a, A: ATLExpressionParser, P: Fn(&'a A) -> Parser<u8, Phi>>(
 }
 
 /// Parses an ATL formula (without whitespace around it)
-pub(crate) fn phi<A: ATLExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
+pub(crate) fn phi<A: AtlExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
     // We have to take left-recursion and precedence into account when making parsers.
     // In ATL formulas, only AND and OR is subject to left-recursion, where AND have higher
     // precedence. So we split ATL formulas into layers: phi s (can contain AND),
@@ -56,14 +56,14 @@ pub(crate) fn phi<A: ATLExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
 }
 
 /// Parses an ATL term (Can't contain AND and without whitespace around it)
-fn term<A: ATLExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
+fn term<A: AtlExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
     let or = (primary(expr_parser) - ws() - sym(b'|') - ws() + lazy(&term, expr_parser))
         .map(|(lhs, rhs)| Phi::Or(Arc::new(lhs), Arc::new(rhs)));
     or | primary(expr_parser)
 }
 
 /// Parses a primary ATL formula (no ANDs or ORs)
-fn primary<A: ATLExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
+fn primary<A: AtlExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
     paren(expr_parser)
         | boolean()
         | proposition(expr_parser)
@@ -79,44 +79,44 @@ fn primary<A: ATLExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
 }
 
 /// Parses an ATL formula in parenthesis
-fn paren<A: ATLExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
+fn paren<A: AtlExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
     sym(b'(') * ws() * lazy(&phi, expr_parser) - ws() - sym(b')')
 }
 
 /// Parses an enforce-coalition (path qualifier)
-fn enforce_players<A: ATLExpressionParser>(expr_parser: &A) -> Parser<u8, Vec<usize>> {
+fn enforce_players<A: AtlExpressionParser>(expr_parser: &A) -> Parser<u8, Vec<usize>> {
     seq(b"<<") * ws() * players(expr_parser) - ws() - seq(b">>")
 }
 
 /// Parses a despite-coalition (path qualifier)
-fn despite_players<A: ATLExpressionParser>(expr_parser: &A) -> Parser<u8, Vec<usize>> {
+fn despite_players<A: AtlExpressionParser>(expr_parser: &A) -> Parser<u8, Vec<usize>> {
     seq(b"[[") * ws() * players(expr_parser) - ws() - seq(b"]]")
 }
 
 /// Parses an path formula starting with the NEXT (X) operator
-fn next<A: ATLExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
+fn next<A: AtlExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
     sym(b'X') * ws() * lazy(&phi, expr_parser)
 }
 
 /// Parses an path formula with the UNTIL operator
-fn until<A: ATLExpressionParser>(expr_parser: &A) -> Parser<u8, (Phi, Phi)> {
+fn until<A: AtlExpressionParser>(expr_parser: &A) -> Parser<u8, (Phi, Phi)> {
     sym(b'(') * ws() * lazy(&phi, expr_parser) - ws() - sym(b'U') - ws() + lazy(&phi, expr_parser)
         - ws()
         - sym(b')')
 }
 
 /// Parses an path formula starting with the EVENTUALLY (F/finally) operator
-fn eventually<A: ATLExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
+fn eventually<A: AtlExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
     sym(b'F') * ws() * lazy(&phi, expr_parser)
 }
 
 /// Parses an path formula starting with the INVARIANT (G/global) operator
-fn invariant<A: ATLExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
+fn invariant<A: AtlExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
     sym(b'G') * ws() * lazy(&phi, expr_parser)
 }
 
 /// Parses an ENFORCE-NEXT ATL formula
-fn enforce_next<A: ATLExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
+fn enforce_next<A: AtlExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
     (enforce_players(expr_parser) - ws() + next(expr_parser)).map(|(players, phi)| {
         Phi::EnforceNext {
             players,
@@ -126,7 +126,7 @@ fn enforce_next<A: ATLExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
 }
 
 /// Parses an ENFORCE-UNTIL ATL formula
-fn enforce_until<A: ATLExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
+fn enforce_until<A: AtlExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
     (enforce_players(expr_parser) - ws() + until(expr_parser)).map(|(players, (l, r))| {
         Phi::EnforceUntil {
             players,
@@ -137,7 +137,7 @@ fn enforce_until<A: ATLExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
 }
 
 /// Parses an ENFORCE-EVENTUALLY ATL formula
-fn enforce_eventually<A: ATLExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
+fn enforce_eventually<A: AtlExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
     (enforce_players(expr_parser) - ws() + eventually(expr_parser)).map(|(players, phi)| {
         Phi::EnforceEventually {
             players,
@@ -147,7 +147,7 @@ fn enforce_eventually<A: ATLExpressionParser>(expr_parser: &A) -> Parser<u8, Phi
 }
 
 /// Parses an ENFORCE-INVARIANT ATL formula
-fn enforce_invariant<A: ATLExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
+fn enforce_invariant<A: AtlExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
     (enforce_players(expr_parser) - ws() + invariant(expr_parser)).map(|(players, phi)| {
         Phi::EnforceInvariant {
             players,
@@ -157,7 +157,7 @@ fn enforce_invariant<A: ATLExpressionParser>(expr_parser: &A) -> Parser<u8, Phi>
 }
 
 /// Parses an DESPITE-NEXT ATL formula
-fn despite_next<A: ATLExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
+fn despite_next<A: AtlExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
     (despite_players(expr_parser) - ws() + next(expr_parser)).map(|(players, phi)| {
         Phi::DespiteNext {
             players,
@@ -167,7 +167,7 @@ fn despite_next<A: ATLExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
 }
 
 /// Parses an DESPITE-UNTIL ATL formula
-fn despite_until<A: ATLExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
+fn despite_until<A: AtlExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
     (despite_players(expr_parser) - ws() + until(expr_parser)).map(|(players, (l, r))| {
         Phi::DespiteUntil {
             players,
@@ -178,7 +178,7 @@ fn despite_until<A: ATLExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
 }
 
 /// Parses an DESPITE-EVENTUALLY ATL formula
-fn despite_eventually<A: ATLExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
+fn despite_eventually<A: AtlExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
     (despite_players(expr_parser) - ws() + eventually(expr_parser)).map(|(players, phi)| {
         Phi::DespiteEventually {
             players,
@@ -188,7 +188,7 @@ fn despite_eventually<A: ATLExpressionParser>(expr_parser: &A) -> Parser<u8, Phi
 }
 
 /// Parses an DESPITE-INVARIANT ATL formula
-fn despite_invariant<A: ATLExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
+fn despite_invariant<A: AtlExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
     (despite_players(expr_parser) - ws() + invariant(expr_parser)).map(|(players, phi)| {
         Phi::DespiteInvariant {
             players,
@@ -198,14 +198,14 @@ fn despite_invariant<A: ATLExpressionParser>(expr_parser: &A) -> Parser<u8, Phi>
 }
 
 /// Parses a proposition using the given [ATLExpressionParser].
-fn proposition<A: ATLExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
+fn proposition<A: AtlExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
     expr_parser
         .proposition_parser()
         .map(|id| Phi::Proposition(id))
 }
 
 /// Parses a negated ATL formula
-fn not<A: ATLExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
+fn not<A: AtlExpressionParser>(expr_parser: &A) -> Parser<u8, Phi> {
     (sym(b'!') * ws() * lazy(&phi, expr_parser)).map(|phi| Phi::Not(Arc::new(phi)))
 }
 
@@ -218,7 +218,7 @@ fn boolean<'a>() -> Parser<'a, u8, Phi> {
 }
 
 /// Parses a comma-separated list of players using the given [ATLExpressionParser].
-fn players<A: ATLExpressionParser>(expr_parser: &A) -> Parser<u8, Vec<usize>> {
+fn players<A: AtlExpressionParser>(expr_parser: &A) -> Parser<u8, Vec<usize>> {
     list(expr_parser.player_parser(), ws() * sym(b',') * ws())
 }
 
@@ -265,7 +265,7 @@ mod test {
         boolean, despite_eventually, despite_invariant, despite_next, despite_players,
         despite_until, enforce_eventually, enforce_invariant, enforce_next, enforce_players,
         enforce_until, eventually, invariant, next, not, number, paren, phi, proposition, term,
-        until, ATLExpressionParser,
+        until, AtlExpressionParser,
     };
     use crate::atl::{parse_phi, Phi};
     use crate::game_structure::lcgs::ir::intermediate::IntermediateLcgs;
@@ -274,7 +274,7 @@ mod test {
 
     struct TestModel;
 
-    impl ATLExpressionParser for TestModel {
+    impl AtlExpressionParser for TestModel {
         fn player_parser(&self) -> Parser<u8, Player> {
             number()
         }

--- a/atl-checker/src/edg/atlcgsedg.rs
+++ b/atl-checker/src/edg/atlcgsedg.rs
@@ -8,28 +8,28 @@ use crate::edg::{Edge, ExtendedDependencyGraph, HyperEdge, NegationEdge, Vertex}
 use crate::game_structure::{GameStructure, Player, State};
 
 #[derive(Clone, Debug)]
-pub struct ATLDependencyGraph<G: GameStructure> {
+pub struct AtlDependencyGraph<G: GameStructure> {
     pub game_structure: G,
 }
 
 #[derive(Clone, Hash, Eq, PartialEq, Debug)]
-pub enum ATLVertex {
-    FULL {
+pub enum AtlVertex {
+    Full {
         state: State,
         formula: Arc<Phi>,
     },
-    PARTIAL {
+    Partial {
         state: State,
         partial_move: PartialMove,
         formula: Arc<Phi>,
     },
 }
 
-impl Display for ATLVertex {
+impl Display for AtlVertex {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            ATLVertex::FULL { state, formula } => write!(f, "state={} formula={}", state, formula),
-            ATLVertex::PARTIAL {
+            AtlVertex::Full { state, formula } => write!(f, "state={} formula={}", state, formula),
+            AtlVertex::Partial {
                 state,
                 partial_move,
                 formula,
@@ -47,37 +47,37 @@ impl Display for ATLVertex {
     }
 }
 
-impl ATLVertex {
+impl AtlVertex {
     pub fn state(&self) -> State {
         match self {
-            ATLVertex::FULL { state, .. } => *state,
-            ATLVertex::PARTIAL { state, .. } => *state,
+            AtlVertex::Full { state, .. } => *state,
+            AtlVertex::Partial { state, .. } => *state,
         }
     }
 
     pub fn formula(&self) -> Arc<Phi> {
         match self {
-            ATLVertex::FULL { formula, .. } => formula.clone(),
-            ATLVertex::PARTIAL { formula, .. } => formula.clone(),
+            AtlVertex::Full { formula, .. } => formula.clone(),
+            AtlVertex::Partial { formula, .. } => formula.clone(),
         }
     }
 }
 
-impl Vertex for ATLVertex {}
+impl Vertex for AtlVertex {}
 
 #[derive(Debug, Eq, PartialEq, Clone, Hash)]
 pub enum PartialMoveChoice {
     /// Range from 0 to given number
-    RANGE(usize),
+    Range(usize),
     /// Chosen move for player
-    SPECIFIC(usize),
+    Specific(usize),
 }
 
 impl Display for PartialMoveChoice {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            PartialMoveChoice::RANGE(max) => write!(f, "(0..{})", max - 1),
-            PartialMoveChoice::SPECIFIC(choice) => write!(f, "{}", choice),
+            PartialMoveChoice::Range(max) => write!(f, "(0..{})", max - 1),
+            PartialMoveChoice::Specific(choice) => write!(f, "{}", choice),
         }
     }
 }
@@ -112,8 +112,8 @@ impl<'a> PartialMoveIterator<'a> {
             .partial_move
             .iter()
             .map(|case| match case {
-                PartialMoveChoice::RANGE(_) => 0,
-                PartialMoveChoice::SPECIFIC(n) => *n,
+                PartialMoveChoice::Range(_) => 0,
+                PartialMoveChoice::Specific(n) => *n,
             })
             .collect();
     }
@@ -129,8 +129,8 @@ impl<'a> PartialMoveIterator<'a> {
             // The next player's move has rolled over or doesn't exist.
             // Then it is our turn to roll -- only RANGE can roll, SPECIFIC should not change
             match self.partial_move[player] {
-                PartialMoveChoice::SPECIFIC(_) => false,
-                PartialMoveChoice::RANGE(n) => {
+                PartialMoveChoice::Specific(_) => false,
+                PartialMoveChoice::Range(n) => {
                     let current = &mut self.current;
                     // Increase move index and return true if it's valid
                     current[player] += 1;
@@ -186,9 +186,9 @@ impl PmovesIterator {
         let mut position = Vec::with_capacity(moves.len());
         for (i, mov) in moves.iter().enumerate() {
             position.push(if players.contains(&i) {
-                PartialMoveChoice::SPECIFIC(0)
+                PartialMoveChoice::Specific(0)
             } else {
-                PartialMoveChoice::RANGE(*mov)
+                PartialMoveChoice::Range(*mov)
             })
         }
 
@@ -219,19 +219,19 @@ impl Iterator for PmovesIterator {
             }
 
             match self.position[roll_over_pos] {
-                PartialMoveChoice::RANGE(_) => {
+                PartialMoveChoice::Range(_) => {
                     roll_over_pos += 1;
                     continue;
                 }
-                PartialMoveChoice::SPECIFIC(value) => {
+                PartialMoveChoice::Specific(value) => {
                     let new_value = value + 1;
 
                     if new_value >= self.moves[roll_over_pos] {
                         // Rolled over
-                        self.position[roll_over_pos] = PartialMoveChoice::SPECIFIC(0);
+                        self.position[roll_over_pos] = PartialMoveChoice::Specific(0);
                         roll_over_pos += 1;
                     } else {
-                        self.position[roll_over_pos] = PartialMoveChoice::SPECIFIC(new_value);
+                        self.position[roll_over_pos] = PartialMoveChoice::Specific(new_value);
                         break;
                     }
                 }
@@ -291,7 +291,7 @@ impl<'a, G: GameStructure> Iterator for DeltaIterator<'a, G> {
     }
 }
 
-impl<G: GameStructure> ATLDependencyGraph<G> {
+impl<G: GameStructure> AtlDependencyGraph<G> {
     #[allow(dead_code)]
     fn invert_players(&self, players: &[Player]) -> HashSet<Player> {
         let max_players = self.game_structure.max_player();
@@ -307,14 +307,14 @@ impl<G: GameStructure> ATLDependencyGraph<G> {
     }
 }
 
-impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph<G> {
+impl<G: GameStructure> ExtendedDependencyGraph<AtlVertex> for AtlDependencyGraph<G> {
     /// Produce the edges of the given vertex
     /// Where possible, the smallest edge will be the first in the produced vector,
     /// and similarly, the smallest target will be the first in the edges' vector of targets.
     /// This is mostly relevant for the Until formulae
-    fn succ(&self, vert: &ATLVertex) -> Vec<Edge<ATLVertex>> {
+    fn succ(&self, vert: &AtlVertex) -> Vec<Edge<AtlVertex>> {
         match vert {
-            ATLVertex::FULL { state, formula } => match formula.as_ref() {
+            AtlVertex::Full { state, formula } => match formula.as_ref() {
                 Phi::True => {
                     // Hyper edge with no targets
                     vec![Edge::Hyper(HyperEdge {
@@ -340,7 +340,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                 Phi::Not(phi) => {
                     vec![Edge::Negation(NegationEdge {
                         source: vert.clone(),
-                        target: ATLVertex::FULL {
+                        target: AtlVertex::Full {
                             state: *state,
                             formula: phi.clone(),
                         },
@@ -350,14 +350,14 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                     vec![
                         Edge::Hyper(HyperEdge {
                             source: vert.clone(),
-                            targets: vec![ATLVertex::FULL {
+                            targets: vec![AtlVertex::Full {
                                 state: *state,
                                 formula: left.clone(),
                             }],
                         }),
                         Edge::Hyper(HyperEdge {
                             source: vert.clone(),
-                            targets: vec![ATLVertex::FULL {
+                            targets: vec![AtlVertex::Full {
                                 state: *state,
                                 formula: right.clone(),
                             }],
@@ -368,11 +368,11 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                     vec![Edge::Hyper(HyperEdge {
                         source: vert.clone(),
                         targets: vec![
-                            ATLVertex::FULL {
+                            AtlVertex::Full {
                                 state: *state,
                                 formula: left.clone(),
                             },
-                            ATLVertex::FULL {
+                            AtlVertex::Full {
                                 state: *state,
                                 formula: right.clone(),
                             },
@@ -381,9 +381,9 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                 }
                 Phi::DespiteNext { players, formula } => {
                     let moves = self.game_structure.move_count(*state);
-                    let targets: Vec<ATLVertex> =
+                    let targets: Vec<AtlVertex> =
                         PmovesIterator::new(moves, players.iter().copied().collect())
-                            .map(|pmove| ATLVertex::PARTIAL {
+                            .map(|pmove| AtlVertex::Partial {
                                 state: *state,
                                 partial_move: pmove,
                                 formula: formula.clone(),
@@ -399,9 +399,9 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                     let moves = self.game_structure.move_count(*state);
                     PmovesIterator::new(moves, players.iter().copied().collect())
                         .map(|pmove| {
-                            let targets: Vec<ATLVertex> =
+                            let targets: Vec<AtlVertex> =
                                 DeltaIterator::new(&self.game_structure, *state, &pmove)
-                                    .map(|state| ATLVertex::FULL {
+                                    .map(|state| AtlVertex::Full {
                                         state,
                                         formula: formula.clone(),
                                     })
@@ -411,7 +411,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                                 targets,
                             })
                         })
-                        .collect::<Vec<Edge<ATLVertex>>>()
+                        .collect::<Vec<Edge<AtlVertex>>>()
                 }
                 Phi::DespiteUntil {
                     players,
@@ -420,7 +420,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                 } => {
                     // `pre`-target
                     // "Is `pre` formula satisfied now?"
-                    let pre = ATLVertex::FULL {
+                    let pre = AtlVertex::Full {
                         state: *state,
                         formula: pre.clone(),
                     };
@@ -428,10 +428,10 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                     // Together with the `pre` target is all the possible moves by other players,
                     // but it is important that `pre` is the first target
                     let moves = self.game_structure.move_count(*state);
-                    let targets: Vec<ATLVertex> = std::iter::once(pre)
+                    let targets: Vec<AtlVertex> = std::iter::once(pre)
                         .chain(
                             PmovesIterator::new(moves, players.iter().cloned().collect()).map(
-                                |pmove| ATLVertex::PARTIAL {
+                                |pmove| AtlVertex::Partial {
                                     state: *state,
                                     partial_move: pmove,
                                     formula: vert.formula(),
@@ -446,7 +446,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                         // This must be the first edge
                         Edge::Hyper(HyperEdge {
                             source: vert.clone(),
-                            targets: vec![ATLVertex::FULL {
+                            targets: vec![AtlVertex::Full {
                                 state: *state,
                                 formula: until.clone(),
                             }],
@@ -469,7 +469,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                         // This must be the first edge
                         Edge::Hyper(HyperEdge {
                             source: vert.clone(),
-                            targets: vec![ATLVertex::FULL {
+                            targets: vec![AtlVertex::Full {
                                 state: *state,
                                 formula: until.clone(),
                             }],
@@ -478,7 +478,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
 
                     // `pre`-target
                     // "Is `pre` formula satisfied now?"
-                    let pre = ATLVertex::FULL {
+                    let pre = AtlVertex::Full {
                         state: *state,
                         formula: pre.clone(),
                     };
@@ -491,12 +491,12 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                                 // but it is important that `pre` is the first target
                                 let delta =
                                     DeltaIterator::new(&self.game_structure, *state, &pmove).map(
-                                        |state| ATLVertex::FULL {
+                                        |state| AtlVertex::Full {
                                             state,
                                             formula: formula.clone(),
                                         },
                                     );
-                                let targets: Vec<ATLVertex> =
+                                let targets: Vec<AtlVertex> =
                                     std::iter::once(pre.clone()).chain(delta).collect();
                                 Edge::Hyper(HyperEdge {
                                     source: vert.clone(),
@@ -515,9 +515,9 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                     // Partial targets with same formula
                     // "Is the formula satisfied in the next state instead?"
                     let moves = self.game_structure.move_count(*state);
-                    let targets: Vec<ATLVertex> =
+                    let targets: Vec<AtlVertex> =
                         PmovesIterator::new(moves, players.iter().cloned().collect())
-                            .map(|pmove| ATLVertex::PARTIAL {
+                            .map(|pmove| AtlVertex::Partial {
                                 state: *state,
                                 partial_move: pmove,
                                 formula: formula.clone(),
@@ -530,7 +530,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                         // This must be the first edge
                         Edge::Hyper(HyperEdge {
                             source: vert.clone(),
-                            targets: vec![ATLVertex::FULL {
+                            targets: vec![AtlVertex::Full {
                                 state: *state,
                                 formula: subformula.clone(),
                             }],
@@ -551,7 +551,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                         // This must be the first edge
                         Edge::Hyper(HyperEdge {
                             source: vert.clone(),
-                            targets: vec![ATLVertex::FULL {
+                            targets: vec![AtlVertex::Full {
                                 state: *state,
                                 formula: subformula.clone(),
                             }],
@@ -564,9 +564,9 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                     edges.extend(
                         PmovesIterator::new(moves, players.iter().copied().collect()).map(
                             |pmove| {
-                                let targets: Vec<ATLVertex> =
+                                let targets: Vec<AtlVertex> =
                                     DeltaIterator::new(&self.game_structure, *state, &pmove)
-                                        .map(|state| ATLVertex::FULL {
+                                        .map(|state| AtlVertex::Full {
                                             state,
                                             formula: formula.clone(),
                                         })
@@ -587,7 +587,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                 } => {
                     vec![Edge::Negation(NegationEdge {
                         source: vert.clone(),
-                        target: ATLVertex::FULL {
+                        target: AtlVertex::Full {
                             state: *state,
                             // Modified formula, switching to minimum-fixed point domain
                             formula: Arc::new(Phi::EnforceUntil {
@@ -604,7 +604,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                 } => {
                     vec![Edge::Negation(NegationEdge {
                         source: vert.clone(),
-                        target: ATLVertex::FULL {
+                        target: AtlVertex::Full {
                             state: *state,
                             // Modified formula, switching to minimum-fixed point
                             formula: Arc::new(Phi::DespiteUntil {
@@ -616,13 +616,13 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                     })]
                 }
             },
-            ATLVertex::PARTIAL {
+            AtlVertex::Partial {
                 state,
                 partial_move,
                 formula,
             } => DeltaIterator::new(&self.game_structure, *state, partial_move)
                 .map(|state| {
-                    let targets = vec![ATLVertex::FULL {
+                    let targets = vec![AtlVertex::Full {
                         state,
                         formula: formula.clone(),
                     }];
@@ -631,7 +631,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                         targets,
                     })
                 })
-                .collect::<Vec<Edge<ATLVertex>>>(),
+                .collect::<Vec<Edge<AtlVertex>>>(),
         }
     }
 }
@@ -649,9 +649,9 @@ mod test {
     #[test]
     fn partial_move_iterator_01() {
         let partial_move = vec![
-            PartialMoveChoice::RANGE(2),
-            PartialMoveChoice::SPECIFIC(1),
-            PartialMoveChoice::RANGE(2),
+            PartialMoveChoice::Range(2),
+            PartialMoveChoice::Specific(1),
+            PartialMoveChoice::Range(2),
         ];
 
         let mut iter = PartialMoveIterator::new(&partial_move);
@@ -673,33 +673,33 @@ mod test {
         assert_eq!(
             &iter.next(),
             &Some(vec![
-                PartialMoveChoice::SPECIFIC(0),
-                PartialMoveChoice::RANGE(3),
-                PartialMoveChoice::SPECIFIC(0)
+                PartialMoveChoice::Specific(0),
+                PartialMoveChoice::Range(3),
+                PartialMoveChoice::Specific(0)
             ])
         );
         assert_eq!(
             &iter.next(),
             &Some(vec![
-                PartialMoveChoice::SPECIFIC(1),
-                PartialMoveChoice::RANGE(3),
-                PartialMoveChoice::SPECIFIC(0)
+                PartialMoveChoice::Specific(1),
+                PartialMoveChoice::Range(3),
+                PartialMoveChoice::Specific(0)
             ])
         );
         assert_eq!(
             &iter.next(),
             &Some(vec![
-                PartialMoveChoice::SPECIFIC(0),
-                PartialMoveChoice::RANGE(3),
-                PartialMoveChoice::SPECIFIC(1)
+                PartialMoveChoice::Specific(0),
+                PartialMoveChoice::Range(3),
+                PartialMoveChoice::Specific(1)
             ])
         );
         assert_eq!(
             &iter.next(),
             &Some(vec![
-                PartialMoveChoice::SPECIFIC(1),
-                PartialMoveChoice::RANGE(3),
-                PartialMoveChoice::SPECIFIC(1)
+                PartialMoveChoice::Specific(1),
+                PartialMoveChoice::Range(3),
+                PartialMoveChoice::Specific(1)
             ])
         );
     }
@@ -711,19 +711,19 @@ mod test {
         let mut iter = PmovesIterator::new(vec![2, 3, 3], players);
 
         let value = iter.next().unwrap();
-        assert_eq!(value[0], PartialMoveChoice::RANGE(2));
-        assert_eq!(value[1], PartialMoveChoice::RANGE(3));
-        assert_eq!(value[2], PartialMoveChoice::SPECIFIC(0));
+        assert_eq!(value[0], PartialMoveChoice::Range(2));
+        assert_eq!(value[1], PartialMoveChoice::Range(3));
+        assert_eq!(value[2], PartialMoveChoice::Specific(0));
 
         let value = iter.next().unwrap();
-        assert_eq!(value[0], PartialMoveChoice::RANGE(2));
-        assert_eq!(value[1], PartialMoveChoice::RANGE(3));
-        assert_eq!(value[2], PartialMoveChoice::SPECIFIC(1));
+        assert_eq!(value[0], PartialMoveChoice::Range(2));
+        assert_eq!(value[1], PartialMoveChoice::Range(3));
+        assert_eq!(value[2], PartialMoveChoice::Specific(1));
 
         let value = iter.next().unwrap();
-        assert_eq!(value[0], PartialMoveChoice::RANGE(2));
-        assert_eq!(value[1], PartialMoveChoice::RANGE(3));
-        assert_eq!(value[2], PartialMoveChoice::SPECIFIC(2));
+        assert_eq!(value[0], PartialMoveChoice::Range(2));
+        assert_eq!(value[1], PartialMoveChoice::Range(3));
+        assert_eq!(value[2], PartialMoveChoice::Specific(2));
 
         let value = iter.next();
         assert_eq!(value, None);
@@ -738,40 +738,40 @@ mod test {
         let mut iter = PmovesIterator::new(vec![3, 3], players);
 
         let value = iter.next().unwrap();
-        assert_eq!(value[0], PartialMoveChoice::SPECIFIC(0));
-        assert_eq!(value[1], PartialMoveChoice::SPECIFIC(0));
+        assert_eq!(value[0], PartialMoveChoice::Specific(0));
+        assert_eq!(value[1], PartialMoveChoice::Specific(0));
 
         let value = iter.next().unwrap();
-        assert_eq!(value[0], PartialMoveChoice::SPECIFIC(1));
-        assert_eq!(value[1], PartialMoveChoice::SPECIFIC(0));
+        assert_eq!(value[0], PartialMoveChoice::Specific(1));
+        assert_eq!(value[1], PartialMoveChoice::Specific(0));
 
         let value = iter.next().unwrap();
-        assert_eq!(value[0], PartialMoveChoice::SPECIFIC(2));
-        assert_eq!(value[1], PartialMoveChoice::SPECIFIC(0));
+        assert_eq!(value[0], PartialMoveChoice::Specific(2));
+        assert_eq!(value[1], PartialMoveChoice::Specific(0));
 
         let value = iter.next().unwrap();
-        assert_eq!(value[0], PartialMoveChoice::SPECIFIC(0));
-        assert_eq!(value[1], PartialMoveChoice::SPECIFIC(1));
+        assert_eq!(value[0], PartialMoveChoice::Specific(0));
+        assert_eq!(value[1], PartialMoveChoice::Specific(1));
 
         let value = iter.next().unwrap();
-        assert_eq!(value[0], PartialMoveChoice::SPECIFIC(1));
-        assert_eq!(value[1], PartialMoveChoice::SPECIFIC(1));
+        assert_eq!(value[0], PartialMoveChoice::Specific(1));
+        assert_eq!(value[1], PartialMoveChoice::Specific(1));
 
         let value = iter.next().unwrap();
-        assert_eq!(value[0], PartialMoveChoice::SPECIFIC(2));
-        assert_eq!(value[1], PartialMoveChoice::SPECIFIC(1));
+        assert_eq!(value[0], PartialMoveChoice::Specific(2));
+        assert_eq!(value[1], PartialMoveChoice::Specific(1));
 
         let value = iter.next().unwrap();
-        assert_eq!(value[0], PartialMoveChoice::SPECIFIC(0));
-        assert_eq!(value[1], PartialMoveChoice::SPECIFIC(2));
+        assert_eq!(value[0], PartialMoveChoice::Specific(0));
+        assert_eq!(value[1], PartialMoveChoice::Specific(2));
 
         let value = iter.next().unwrap();
-        assert_eq!(value[0], PartialMoveChoice::SPECIFIC(1));
-        assert_eq!(value[1], PartialMoveChoice::SPECIFIC(2));
+        assert_eq!(value[0], PartialMoveChoice::Specific(1));
+        assert_eq!(value[1], PartialMoveChoice::Specific(2));
 
         let value = iter.next().unwrap();
-        assert_eq!(value[0], PartialMoveChoice::SPECIFIC(2));
-        assert_eq!(value[1], PartialMoveChoice::SPECIFIC(2));
+        assert_eq!(value[0], PartialMoveChoice::Specific(2));
+        assert_eq!(value[1], PartialMoveChoice::Specific(2));
 
         assert_eq!(iter.next(), None);
     }
@@ -816,11 +816,11 @@ mod test {
         };
         let state = 0;
         let partial_move = vec![
-            PartialMoveChoice::SPECIFIC(0), // player 0
-            PartialMoveChoice::RANGE(2),    // player 1
-            PartialMoveChoice::SPECIFIC(0), // player 2
-            PartialMoveChoice::RANGE(3),    // player 3
-            PartialMoveChoice::SPECIFIC(0), // player 4
+            PartialMoveChoice::Specific(0), // player 0
+            PartialMoveChoice::Range(2),    // player 1
+            PartialMoveChoice::Specific(0), // player 2
+            PartialMoveChoice::Range(3),    // player 3
+            PartialMoveChoice::Specific(0), // player 4
         ];
         let mut iter = DeltaIterator::new(&game_structure, state, &partial_move);
 

--- a/atl-checker/src/edg/atlcgsedg.rs
+++ b/atl-checker/src/edg/atlcgsedg.rs
@@ -92,6 +92,7 @@ struct PartialMoveIterator<'a> {
     current: Vec<usize>,
 }
 
+#[allow(clippy::ptr_arg)]
 impl<'a> PartialMoveIterator<'a> {
     /// Create a new PartialMoveIterator
     fn new(partial_move: &'a PartialMove) -> PartialMoveIterator {
@@ -253,6 +254,7 @@ struct DeltaIterator<'a, G: GameStructure> {
     known: HashSet<State>,
 }
 
+#[allow(clippy::ptr_arg)]
 impl<'a, G: GameStructure> DeltaIterator<'a, G> {
     /// Create a new DeltaIterator
     fn new(game_structure: &'a G, state: State, moves: &'a PartialMove) -> Self {

--- a/atl-checker/src/edg/atlcgsedg.rs
+++ b/atl-checker/src/edg/atlcgsedg.rs
@@ -779,31 +779,31 @@ mod test {
     #[test]
     fn delta_iterator_01() {
         // player 0
-        let transitions = DynVec::NEST(vec![
+        let transitions = DynVec::Nest(vec![
             // player 1
-            Arc::new(DynVec::NEST(vec![
+            Arc::new(DynVec::Nest(vec![
                 // Player 2
-                Arc::new(DynVec::NEST(vec![
+                Arc::new(DynVec::Nest(vec![
                     // player 3
-                    Arc::new(DynVec::NEST(vec![
+                    Arc::new(DynVec::Nest(vec![
                         // Player 4
-                        Arc::new(DynVec::NEST(vec![Arc::new(DynVec::BASE(1))])),
+                        Arc::new(DynVec::Nest(vec![Arc::new(DynVec::Base(1))])),
                         // Player 4
-                        Arc::new(DynVec::NEST(vec![Arc::new(DynVec::BASE(2))])),
+                        Arc::new(DynVec::Nest(vec![Arc::new(DynVec::Base(2))])),
                         // Player 4
-                        Arc::new(DynVec::NEST(vec![Arc::new(DynVec::BASE(3))])),
+                        Arc::new(DynVec::Nest(vec![Arc::new(DynVec::Base(3))])),
                     ])),
                 ])),
                 // Player 2
-                Arc::new(DynVec::NEST(vec![
+                Arc::new(DynVec::Nest(vec![
                     // player 3
-                    Arc::new(DynVec::NEST(vec![
+                    Arc::new(DynVec::Nest(vec![
                         // Player 4
-                        Arc::new(DynVec::NEST(vec![Arc::new(DynVec::BASE(4))])),
+                        Arc::new(DynVec::Nest(vec![Arc::new(DynVec::Base(4))])),
                         // Player 4
-                        Arc::new(DynVec::NEST(vec![Arc::new(DynVec::BASE(5))])),
+                        Arc::new(DynVec::Nest(vec![Arc::new(DynVec::Base(5))])),
                         // Player 4
-                        Arc::new(DynVec::NEST(vec![Arc::new(DynVec::BASE(1))])),
+                        Arc::new(DynVec::Nest(vec![Arc::new(DynVec::Base(1))])),
                     ])),
                 ])),
             ])),

--- a/atl-checker/src/edg/atlcgsedg.rs
+++ b/atl-checker/src/edg/atlcgsedg.rs
@@ -317,7 +317,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
             ATLVertex::FULL { state, formula } => match formula.as_ref() {
                 Phi::True => {
                     // Hyper edge with no targets
-                    vec![Edge::HYPER(HyperEdge {
+                    vec![Edge::Hyper(HyperEdge {
                         source: vert.clone(),
                         targets: vec![],
                     })]
@@ -329,7 +329,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                 Phi::Proposition(prop) => {
                     let props = self.game_structure.labels(vert.state());
                     if props.contains(prop) {
-                        vec![Edge::HYPER(HyperEdge {
+                        vec![Edge::Hyper(HyperEdge {
                             source: vert.clone(),
                             targets: vec![],
                         })]
@@ -338,7 +338,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                     }
                 }
                 Phi::Not(phi) => {
-                    vec![Edge::NEGATION(NegationEdge {
+                    vec![Edge::Negation(NegationEdge {
                         source: vert.clone(),
                         target: ATLVertex::FULL {
                             state: *state,
@@ -348,14 +348,14 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                 }
                 Phi::Or(left, right) => {
                     vec![
-                        Edge::HYPER(HyperEdge {
+                        Edge::Hyper(HyperEdge {
                             source: vert.clone(),
                             targets: vec![ATLVertex::FULL {
                                 state: *state,
                                 formula: left.clone(),
                             }],
                         }),
-                        Edge::HYPER(HyperEdge {
+                        Edge::Hyper(HyperEdge {
                             source: vert.clone(),
                             targets: vec![ATLVertex::FULL {
                                 state: *state,
@@ -365,7 +365,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                     ]
                 }
                 Phi::And(left, right) => {
-                    vec![Edge::HYPER(HyperEdge {
+                    vec![Edge::Hyper(HyperEdge {
                         source: vert.clone(),
                         targets: vec![
                             ATLVertex::FULL {
@@ -390,7 +390,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                             })
                             .collect();
 
-                    vec![Edge::HYPER(HyperEdge {
+                    vec![Edge::Hyper(HyperEdge {
                         source: vert.clone(),
                         targets,
                     })]
@@ -406,7 +406,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                                         formula: formula.clone(),
                                     })
                                     .collect();
-                            Edge::HYPER(HyperEdge {
+                            Edge::Hyper(HyperEdge {
                                 source: vert.clone(),
                                 targets,
                             })
@@ -444,7 +444,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                         // `until`-formula branch
                         // "Is the `until` formula satisfied now?"
                         // This must be the first edge
-                        Edge::HYPER(HyperEdge {
+                        Edge::Hyper(HyperEdge {
                             source: vert.clone(),
                             targets: vec![ATLVertex::FULL {
                                 state: *state,
@@ -452,7 +452,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                             }],
                         }),
                         // Other branches where pre is satisfied
-                        Edge::HYPER(HyperEdge {
+                        Edge::Hyper(HyperEdge {
                             source: vert.clone(),
                             targets,
                         }),
@@ -467,7 +467,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                         // `until`-formula branch
                         // "Is the `until` formula satisfied now?"
                         // This must be the first edge
-                        Edge::HYPER(HyperEdge {
+                        Edge::Hyper(HyperEdge {
                             source: vert.clone(),
                             targets: vec![ATLVertex::FULL {
                                 state: *state,
@@ -498,7 +498,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                                     );
                                 let targets: Vec<ATLVertex> =
                                     std::iter::once(pre.clone()).chain(delta).collect();
-                                Edge::HYPER(HyperEdge {
+                                Edge::Hyper(HyperEdge {
                                     source: vert.clone(),
                                     targets,
                                 })
@@ -528,14 +528,14 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                         // sub-formula target
                         // "Is the sub formula satisfied in current state?"
                         // This must be the first edge
-                        Edge::HYPER(HyperEdge {
+                        Edge::Hyper(HyperEdge {
                             source: vert.clone(),
                             targets: vec![ATLVertex::FULL {
                                 state: *state,
                                 formula: subformula.clone(),
                             }],
                         }),
-                        Edge::HYPER(HyperEdge {
+                        Edge::Hyper(HyperEdge {
                             source: vert.clone(),
                             targets,
                         }),
@@ -549,7 +549,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                         // sub-formula target
                         // "Is the sub formula satisfied in current state?"
                         // This must be the first edge
-                        Edge::HYPER(HyperEdge {
+                        Edge::Hyper(HyperEdge {
                             source: vert.clone(),
                             targets: vec![ATLVertex::FULL {
                                 state: *state,
@@ -571,7 +571,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                                             formula: formula.clone(),
                                         })
                                         .collect();
-                                Edge::HYPER(HyperEdge {
+                                Edge::Hyper(HyperEdge {
                                     source: vert.clone(),
                                     targets,
                                 })
@@ -585,7 +585,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                     players,
                     formula: subformula,
                 } => {
-                    vec![Edge::NEGATION(NegationEdge {
+                    vec![Edge::Negation(NegationEdge {
                         source: vert.clone(),
                         target: ATLVertex::FULL {
                             state: *state,
@@ -602,7 +602,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                     players,
                     formula: subformula,
                 } => {
-                    vec![Edge::NEGATION(NegationEdge {
+                    vec![Edge::Negation(NegationEdge {
                         source: vert.clone(),
                         target: ATLVertex::FULL {
                             state: *state,
@@ -626,7 +626,7 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                         state,
                         formula: formula.clone(),
                     }];
-                    Edge::HYPER(HyperEdge {
+                    Edge::Hyper(HyperEdge {
                         source: vert.clone(),
                         targets,
                     })

--- a/atl-checker/src/edg/mod.rs
+++ b/atl-checker/src/edg/mod.rs
@@ -25,6 +25,6 @@ pub struct NegationEdge<V: Hash + Eq + PartialEq + Clone> {
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub enum Edge<V: Hash + Eq + PartialEq + Clone> {
-    HYPER(HyperEdge<V>),
-    NEGATION(NegationEdge<V>),
+    Hyper(HyperEdge<V>),
+    Negation(NegationEdge<V>),
 }

--- a/atl-checker/src/game_structure/eager.rs
+++ b/atl-checker/src/game_structure/eager.rs
@@ -1,7 +1,7 @@
 use std::collections::hash_map::RandomState;
 use std::collections::HashSet;
 
-use crate::atl::{number, ATLExpressionParser};
+use crate::atl::{number, AtlExpressionParser};
 use crate::game_structure::{transition_lookup, DynVec, GameStructure, Player, Proposition, State};
 use pom::parser::Parser;
 use std::str::{self};
@@ -82,7 +82,7 @@ impl GameStructure for EagerGameStructure {
     }
 }
 
-impl ATLExpressionParser for EagerGameStructure {
+impl AtlExpressionParser for EagerGameStructure {
     fn player_parser(&self) -> Parser<u8, Player> {
         // In ATL, players are just their index
         number().convert(move |i| {

--- a/atl-checker/src/game_structure/lcgs/ir/intermediate.rs
+++ b/atl-checker/src/game_structure/lcgs/ir/intermediate.rs
@@ -48,24 +48,24 @@ impl Player {
 /// An [IntermediateLCGS] is created from processing an AST and checking the validity of the
 /// declarations.
 #[derive(Clone, Debug)]
-pub struct IntermediateLCGS {
+pub struct IntermediateLcgs {
     symbols: HashMap<SymbolIdentifier, Decl>,
     labels: Vec<SymbolIdentifier>,
     vars: Vec<SymbolIdentifier>,
     players: Vec<Player>,
 }
 
-impl IntermediateLCGS {
+impl IntermediateLcgs {
     /// Create an [IntermediateLCGS] from an AST root. All declarations in the resulting
     /// [IntermediateLCGS] are symbol checked and type checked.
-    pub fn create(root: Root) -> Result<IntermediateLCGS, Error> {
+    pub fn create(root: Root) -> Result<IntermediateLcgs, Error> {
         let mut symbols = SymbolTable::new();
 
         // Register global decls. Then check and optimize them
         let (players, labels, vars) = register_decls(&mut symbols, root)?;
         check_and_optimize_decls(&symbols)?;
 
-        let ilcgs = IntermediateLCGS {
+        let ilcgs = IntermediateLcgs {
             symbols: symbols.solidify(),
             labels,
             vars,
@@ -427,7 +427,7 @@ impl Display for State {
     }
 }
 
-impl GameStructure for IntermediateLCGS {
+impl GameStructure for IntermediateLcgs {
     fn max_player(&self) -> usize {
         self.players.len()
     }
@@ -528,7 +528,7 @@ impl GameStructure for IntermediateLCGS {
     }
 }
 
-impl ATLExpressionParser for IntermediateLCGS {
+impl ATLExpressionParser for IntermediateLcgs {
     fn player_parser(&self) -> Parser<u8, game_structure::Player> {
         // In ATL, players are referred to using their name, i.e. an identifier
         identifier().convert(move |name| {
@@ -589,7 +589,7 @@ impl ATLExpressionParser for IntermediateLCGS {
 #[cfg(test)]
 mod test {
     use crate::game_structure::lcgs::ast::DeclKind;
-    use crate::game_structure::lcgs::ir::intermediate::{IntermediateLCGS, State};
+    use crate::game_structure::lcgs::ir::intermediate::{IntermediateLcgs, State};
     use crate::game_structure::lcgs::ir::symbol_table::Owner;
     use crate::game_structure::lcgs::ir::symbol_table::SymbolIdentifier;
     use crate::game_structure::lcgs::parse::parse_lcgs;
@@ -614,7 +614,7 @@ mod test {
             [shoot] health > 0;
         endtemplate
         ";
-        let lcgs = IntermediateLCGS::create(parse_lcgs(input).unwrap()).unwrap();
+        let lcgs = IntermediateLcgs::create(parse_lcgs(input).unwrap()).unwrap();
         assert_eq!(lcgs.symbols.len(), 12);
         assert!(lcgs.symbols.get(&":global.max_health".into()).is_some());
         assert!(lcgs.symbols.get(&":global.alice".into()).is_some());
@@ -637,7 +637,7 @@ mod test {
         foo : [1 .. 10] init 1;
         foo' = foo;
         ";
-        let lcgs1 = IntermediateLCGS::create(parse_lcgs(input1).unwrap()).unwrap();
+        let lcgs1 = IntermediateLcgs::create(parse_lcgs(input1).unwrap()).unwrap();
         assert_eq!(lcgs1.symbols.len(), 1);
         assert!(lcgs1.symbols.get(&":global.foo".into()).is_some());
 
@@ -645,7 +645,7 @@ mod test {
         let input2 = "
         label foo = foo > 0;
         ";
-        let lcgs2 = IntermediateLCGS::create(parse_lcgs(input2).unwrap());
+        let lcgs2 = IntermediateLcgs::create(parse_lcgs(input2).unwrap());
         assert!(lcgs2.is_err());
     }
 
@@ -667,7 +667,7 @@ mod test {
             [shoot] health > 0 && enemy.health > 0;
         endtemplate
         ";
-        let lcgs = IntermediateLCGS::create(parse_lcgs(input).unwrap()).unwrap();
+        let lcgs = IntermediateLcgs::create(parse_lcgs(input).unwrap()).unwrap();
         assert_eq!(lcgs.symbols.len(), 12);
         assert!(lcgs.symbols.get(&":global.max_health".into()).is_some());
         assert!(lcgs.symbols.get(&":global.anna".into()).is_some());
@@ -697,7 +697,7 @@ mod test {
             label prop = 1;
         endtemplate
         ";
-        let lcgs = IntermediateLCGS::create(parse_lcgs(input).unwrap()).unwrap();
+        let lcgs = IntermediateLcgs::create(parse_lcgs(input).unwrap()).unwrap();
         assert_eq!(lcgs.symbols.len(), 9);
         assert!(lcgs.symbols.get(&":global.anna".into()).is_some());
         assert!(lcgs.symbols.get(&":global.bob".into()).is_some());
@@ -724,7 +724,7 @@ mod test {
             [act] 1;
         endtemplate
         ";
-        let lcgs = IntermediateLCGS::create(parse_lcgs(input).unwrap()).unwrap();
+        let lcgs = IntermediateLcgs::create(parse_lcgs(input).unwrap()).unwrap();
         assert_eq!(lcgs.symbols.len(), 9);
         assert!(lcgs.symbols.get(&":global.anna".into()).is_some());
         assert!(lcgs.symbols.get(&":global.bob".into()).is_some());
@@ -747,7 +747,7 @@ mod test {
         bar : [0 .. 5] init 0;
         bar' = bar;
         ";
-        let lcgs = IntermediateLCGS::create(parse_lcgs(input).unwrap()).unwrap();
+        let lcgs = IntermediateLcgs::create(parse_lcgs(input).unwrap()).unwrap();
         let index = 23;
         let state = lcgs.state_from_index(index);
         let index2 = lcgs.index_of_state(&state);
@@ -766,7 +766,7 @@ mod test {
         yum : [100 .. 102] init 100;
         yum' = yum;
         ";
-        let lcgs = IntermediateLCGS::create(parse_lcgs(input).unwrap()).unwrap();
+        let lcgs = IntermediateLcgs::create(parse_lcgs(input).unwrap()).unwrap();
         let indexes = [12, 55, 126, 78, 99];
         for i in &indexes {
             let state = lcgs.state_from_index(*i);
@@ -785,7 +785,7 @@ mod test {
         bar : [-5 .. -3] init -3;
         bar' = bar;
         ";
-        let lcgs = IntermediateLCGS::create(parse_lcgs(input).unwrap()).unwrap();
+        let lcgs = IntermediateLcgs::create(parse_lcgs(input).unwrap()).unwrap();
         let index = 14;
         let state = lcgs.state_from_index(index);
         let index2 = lcgs.index_of_state(&state);
@@ -814,7 +814,7 @@ mod test {
             [wait] 1;
         endtemplate
         ";
-        let lcgs = IntermediateLCGS::create(parse_lcgs(input).unwrap()).unwrap();
+        let lcgs = IntermediateLcgs::create(parse_lcgs(input).unwrap()).unwrap();
         let indexes = [12, 55, 126, 78, 99, 150, 555, 992, 1001, 733];
         for i in &indexes {
             let state = lcgs.state_from_index(*i);
@@ -835,7 +835,7 @@ mod test {
         ";
 
         // Index to state to index
-        let lcgs = IntermediateLCGS::create(parse_lcgs(input).unwrap()).unwrap();
+        let lcgs = IntermediateLcgs::create(parse_lcgs(input).unwrap()).unwrap();
         let indexes = [12_340, 1_987_158, 3_000_000_000];
         for i in &indexes {
             let state = lcgs.state_from_index(*i);
@@ -859,12 +859,12 @@ mod test {
         const t = -5;
         ";
         let pp = parse_lcgs(input);
-        let lcgs = IntermediateLCGS::create(pp.unwrap()).unwrap();
+        let lcgs = IntermediateLcgs::create(pp.unwrap()).unwrap();
         assert!(lcgs.symbols.get(&":global.t".into()).is_some());
     }
 
     /// Helper function to get the index of a label with the given symbol name
-    fn get_label_index(lcgs: &IntermediateLCGS, symbol_name: &str) -> usize {
+    fn get_label_index(lcgs: &IntermediateLcgs, symbol_name: &str) -> usize {
         let symbol = lcgs.symbols.get(&symbol_name.into()).unwrap();
         if let DeclKind::Label(label) = &symbol.kind {
             label.index
@@ -883,7 +883,7 @@ mod test {
         bar' = bar;
         label cool = foo;
         ";
-        let lcgs = IntermediateLCGS::create(parse_lcgs(input).unwrap()).unwrap();
+        let lcgs = IntermediateLcgs::create(parse_lcgs(input).unwrap()).unwrap();
         let labels = lcgs.labels(23);
         assert!(labels.contains(&0usize));
         assert_eq!(get_label_index(&lcgs, ":global.cool"), 0usize);
@@ -901,7 +901,7 @@ mod test {
         label great = bar == 0;
         label awesome = foo > bar;
         ";
-        let lcgs = IntermediateLCGS::create(parse_lcgs(input).unwrap()).unwrap();
+        let lcgs = IntermediateLcgs::create(parse_lcgs(input).unwrap()).unwrap();
         let labels = lcgs.labels(46);
         assert!(labels.contains(&0usize));
         assert_eq!(get_label_index(&lcgs, ":global.cool"), 0usize);
@@ -926,7 +926,7 @@ mod test {
             [wait] 1;
         endtemplate
         ";
-        let lcgs = IntermediateLCGS::create(parse_lcgs(input).unwrap()).unwrap();
+        let lcgs = IntermediateLcgs::create(parse_lcgs(input).unwrap()).unwrap();
         let labels = lcgs.labels(5);
         assert!(!labels.contains(&0usize));
         assert_eq!(get_label_index(&lcgs, ":global.no"), 0usize);
@@ -953,7 +953,7 @@ mod test {
             [move] foo > 0;
         endtemplate
         ";
-        let lcgs = IntermediateLCGS::create(parse_lcgs(input).unwrap()).unwrap();
+        let lcgs = IntermediateLcgs::create(parse_lcgs(input).unwrap()).unwrap();
         let move_count = lcgs.move_count(4);
         assert_eq!(move_count[0], 1);
         assert_eq!(move_count[1], 2);
@@ -970,7 +970,7 @@ mod test {
             [swap] 1;
         endtemplate
         ";
-        let lcgs = IntermediateLCGS::create(parse_lcgs(input).unwrap()).unwrap();
+        let lcgs = IntermediateLcgs::create(parse_lcgs(input).unwrap()).unwrap();
         let next_state = lcgs.transitions(0, vec![0]);
         assert_eq!(1, next_state);
         let next_next_state = lcgs.transitions(next_state, vec![0]);
@@ -989,7 +989,7 @@ mod test {
             [set_foo] 1;
         endtemplate
         ";
-        let lcgs = IntermediateLCGS::create(parse_lcgs(input).unwrap()).unwrap();
+        let lcgs = IntermediateLcgs::create(parse_lcgs(input).unwrap()).unwrap();
         assert_eq!(0, lcgs.transitions(0, vec![0]));
         assert_eq!(1, lcgs.transitions(0, vec![1]));
         assert_eq!(0, lcgs.transitions(1, vec![0]));
@@ -1010,7 +1010,7 @@ mod test {
             [available_action] 1; 
         endtemplate
         ";
-        let lcgs = IntermediateLCGS::create(parse_lcgs(input).unwrap()).unwrap();
+        let lcgs = IntermediateLcgs::create(parse_lcgs(input).unwrap()).unwrap();
         let init_state = lcgs.initial_state_index();
         assert_eq!(0, init_state);
         assert_eq!(0, lcgs.transitions(init_state, vec![0]));
@@ -1025,7 +1025,7 @@ mod test {
         bar : [0 .. 1] init 1;
         bar' = bar;
         ";
-        let lcgs = IntermediateLCGS::create(parse_lcgs(input).unwrap()).unwrap();
+        let lcgs = IntermediateLcgs::create(parse_lcgs(input).unwrap()).unwrap();
         assert_eq!(2, lcgs.initial_state_index());
     }
 
@@ -1039,12 +1039,12 @@ mod test {
         bar : [1 .. 6] init 1;
         bar' = bar;
         ";
-        let lcgs = IntermediateLCGS::create(parse_lcgs(input).unwrap()).unwrap();
+        let lcgs = IntermediateLcgs::create(parse_lcgs(input).unwrap()).unwrap();
         assert_eq!(1, lcgs.initial_state_index());
     }
 
     /// Helper function to get the index of a player with the given name
-    fn get_player_index(lcgs: &IntermediateLCGS, player_name: &str) -> usize {
+    fn get_player_index(lcgs: &IntermediateLcgs, player_name: &str) -> usize {
         let symbol = lcgs
             .symbols
             .get(&Owner::Global.symbol_id(player_name))
@@ -1067,7 +1067,7 @@ mod test {
             [wait] 1;
         endtemplate
         ";
-        let lcgs = IntermediateLCGS::create(parse_lcgs(input).unwrap()).unwrap();
+        let lcgs = IntermediateLcgs::create(parse_lcgs(input).unwrap()).unwrap();
         assert_eq!(get_player_index(&lcgs, "p1"), 0usize);
         assert_eq!(get_player_index(&lcgs, "p2"), 1usize);
         assert_eq!(get_player_index(&lcgs, "p3"), 2usize);

--- a/atl-checker/src/game_structure/lcgs/ir/intermediate.rs
+++ b/atl-checker/src/game_structure/lcgs/ir/intermediate.rs
@@ -1,7 +1,7 @@
 use std::borrow::BorrowMut;
 use std::collections::{HashMap, HashSet};
 
-use crate::atl::{identifier, ATLExpressionParser};
+use crate::atl::{identifier, AtlExpressionParser};
 use crate::game_structure;
 use crate::game_structure::lcgs::ast::{ConstDecl, Decl, DeclKind, ExprKind, Identifier, Root};
 use crate::game_structure::lcgs::ir::error::Error;
@@ -528,7 +528,7 @@ impl GameStructure for IntermediateLcgs {
     }
 }
 
-impl ATLExpressionParser for IntermediateLcgs {
+impl AtlExpressionParser for IntermediateLcgs {
     fn player_parser(&self) -> Parser<u8, game_structure::Player> {
         // In ATL, players are referred to using their name, i.e. an identifier
         identifier().convert(move |name| {

--- a/atl-checker/src/game_structure/lcgs/ir/intermediate.rs
+++ b/atl-checker/src/game_structure/lcgs/ir/intermediate.rs
@@ -462,10 +462,10 @@ impl GameStructure for IntermediateLcgs {
             let moves = self.available_actions(&state, p_index);
             debug_assert!(
                 choices[p_index] < moves.len(),
-                format!(
-                    "Unknown action {} chosen for player {} in state {:?}",
-                    choices[p_index], p_index, state
-                )
+                "Unknown action {} chosen for player {} in state {:?}",
+                choices[p_index],
+                p_index,
+                state
             );
             for (a_index, a_symb_id) in moves.iter().enumerate() {
                 let val = if choices[p_index] == a_index { 1 } else { 0 };

--- a/atl-checker/src/game_structure/lcgs/ir/symbol_checker.rs
+++ b/atl-checker/src/game_structure/lcgs/ir/symbol_checker.rs
@@ -278,7 +278,7 @@ impl<'a> SymbolChecker<'a> {
     }
     /// First combines all numbers, as we already know the max of that
     /// Then returns a new checked Vec of Expr to find Max of.
-    #[allow(clippy::unnecessary_wraps)]
+    #[allow(clippy::unnecessary_wrap)]
     fn check_max(&self, ls: &[Expr]) -> Result<Expr, SymbolError> {
         let checked_list: Vec<Expr> = ls.iter().map(|p| self.check(p).unwrap()).collect();
         let number: Option<i32> = checked_list

--- a/atl-checker/src/game_structure/lcgs/ir/symbol_checker.rs
+++ b/atl-checker/src/game_structure/lcgs/ir/symbol_checker.rs
@@ -243,7 +243,7 @@ impl<'a> SymbolChecker<'a> {
     }
     /// First combines all numbers, as we already know the min of that
     /// Then returns a new checked Vec of Expr to find Min of.
-    #[allow(clippy::unnecessary_unwrap)]
+    #[allow(clippy::unnecessary_wraps)]
     fn check_min(&self, ls: &[Expr]) -> Result<Expr, SymbolError> {
         let checked_list: Vec<Expr> = ls.iter().map(|p| self.check(p).unwrap()).collect();
         let number: Option<i32> = checked_list
@@ -278,7 +278,7 @@ impl<'a> SymbolChecker<'a> {
     }
     /// First combines all numbers, as we already know the max of that
     /// Then returns a new checked Vec of Expr to find Max of.
-    #[allow(clippy::unnecessary_unwrap)]
+    #[allow(clippy::unnecessary_wraps)]
     fn check_max(&self, ls: &[Expr]) -> Result<Expr, SymbolError> {
         let checked_list: Vec<Expr> = ls.iter().map(|p| self.check(p).unwrap()).collect();
         let number: Option<i32> = checked_list

--- a/atl-checker/src/game_structure/lcgs/ir/symbol_checker.rs
+++ b/atl-checker/src/game_structure/lcgs/ir/symbol_checker.rs
@@ -243,7 +243,7 @@ impl<'a> SymbolChecker<'a> {
     }
     /// First combines all numbers, as we already know the min of that
     /// Then returns a new checked Vec of Expr to find Min of.
-    #[allow(clippy::unnecessary_wraps)]
+    #[allow(clippy::unnecessary_wrap)]
     fn check_min(&self, ls: &[Expr]) -> Result<Expr, SymbolError> {
         let checked_list: Vec<Expr> = ls.iter().map(|p| self.check(p).unwrap()).collect();
         let number: Option<i32> = checked_list

--- a/atl-checker/src/game_structure/lcgs/ir/symbol_checker.rs
+++ b/atl-checker/src/game_structure/lcgs/ir/symbol_checker.rs
@@ -243,7 +243,7 @@ impl<'a> SymbolChecker<'a> {
     }
     /// First combines all numbers, as we already know the min of that
     /// Then returns a new checked Vec of Expr to find Min of.
-    #[allow(clippy::unnecessary_wrap)]
+    #[allow(clippy::unnecessary_unwrap)]
     fn check_min(&self, ls: &[Expr]) -> Result<Expr, SymbolError> {
         let checked_list: Vec<Expr> = ls.iter().map(|p| self.check(p).unwrap()).collect();
         let number: Option<i32> = checked_list
@@ -278,7 +278,7 @@ impl<'a> SymbolChecker<'a> {
     }
     /// First combines all numbers, as we already know the max of that
     /// Then returns a new checked Vec of Expr to find Max of.
-    #[allow(clippy::unnecessary_wrap)]
+    #[allow(clippy::unnecessary_unwrap)]
     fn check_max(&self, ls: &[Expr]) -> Result<Expr, SymbolError> {
         let checked_list: Vec<Expr> = ls.iter().map(|p| self.check(p).unwrap()).collect();
         let number: Option<i32> = checked_list

--- a/atl-checker/src/game_structure/lcgs/ir/symbol_checker.rs
+++ b/atl-checker/src/game_structure/lcgs/ir/symbol_checker.rs
@@ -243,6 +243,7 @@ impl<'a> SymbolChecker<'a> {
     }
     /// First combines all numbers, as we already know the min of that
     /// Then returns a new checked Vec of Expr to find Min of.
+    #[allow(clippy::unnecessary_wraps)]
     fn check_min(&self, ls: &[Expr]) -> Result<Expr, SymbolError> {
         let checked_list: Vec<Expr> = ls.iter().map(|p| self.check(p).unwrap()).collect();
         let number: Option<i32> = checked_list
@@ -277,6 +278,7 @@ impl<'a> SymbolChecker<'a> {
     }
     /// First combines all numbers, as we already know the max of that
     /// Then returns a new checked Vec of Expr to find Max of.
+    #[allow(clippy::unnecessary_wraps)]
     fn check_max(&self, ls: &[Expr]) -> Result<Expr, SymbolError> {
         let checked_list: Vec<Expr> = ls.iter().map(|p| self.check(p).unwrap()).collect();
         let number: Option<i32> = checked_list

--- a/atl-checker/src/game_structure/lcgs/ir/symbol_table.rs
+++ b/atl-checker/src/game_structure/lcgs/ir/symbol_table.rs
@@ -62,6 +62,10 @@ impl SymbolTable {
         self.symbols.len()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.symbols.is_empty()
+    }
+
     /// Creates and inserts a symbol for the given declaration for the given owner with the
     /// given name. If the name is already associated with a different symbol, the previous
     /// symbol is returned.

--- a/atl-checker/src/game_structure/mod.rs
+++ b/atl-checker/src/game_structure/mod.rs
@@ -39,15 +39,15 @@ pub trait GameStructure {
 #[derive(Clone, Debug, Deserialize)]
 #[serde(untagged)]
 pub enum DynVec {
-    NEST(Vec<Arc<DynVec>>),
-    BASE(State),
+    Nest(Vec<Arc<DynVec>>),
+    Base(State),
 }
 
 /// Indexes into a DynVec.
 /// The length of `choices` must match the depth of `transitions`.
 pub(crate) fn transition_lookup(choices: &[usize], transitions: &DynVec) -> State {
     match transitions {
-        DynVec::NEST(v) => {
+        DynVec::Nest(v) => {
             if choices.is_empty() {
                 panic!("Fewer choices given than number of players in transitions");
             }
@@ -57,6 +57,6 @@ pub(crate) fn transition_lookup(choices: &[usize], transitions: &DynVec) -> Stat
 
             transition_lookup(&choices[1..choices.len()], h)
         }
-        DynVec::BASE(state) => *state,
+        DynVec::Base(state) => *state,
     }
 }

--- a/atl-checker/src/printer.rs
+++ b/atl-checker/src/printer.rs
@@ -46,7 +46,7 @@ pub fn print_graph<V: Vertex, G: ExtendedDependencyGraph<V>, W: Write>(
             let hyper_id = hash_name(&edge);
 
             match edge {
-                Edge::HYPER(hyper) => {
+                Edge::Hyper(hyper) => {
                     print_vertex(&hyper.source, &mut output)?;
 
                     if hyper.targets.is_empty() {
@@ -103,7 +103,7 @@ pub fn print_graph<V: Vertex, G: ExtendedDependencyGraph<V>, W: Write>(
                         }
                     }
                 }
-                Edge::NEGATION(neg) => {
+                Edge::Negation(neg) => {
                     print_vertex(&neg.source, &mut output)?;
 
                     output.write_all(

--- a/atl-checker/src/simple_edg.rs
+++ b/atl-checker/src/simple_edg.rs
@@ -78,11 +78,11 @@ macro_rules! simple_edg {
             $($vertex_name::$v => {
                 #[allow(unused_mut)]
                 let mut successors = vec![];
-                $(successors.push(Edge::HYPER(HyperEdge {
+                $(successors.push(Edge::Hyper(HyperEdge {
                     source: $vertex_name::$v,
                     targets: vec![$($vertex_name::$t),*],
                 }));)*
-                $(successors.push(Edge::NEGATION(NegationEdge {
+                $(successors.push(Edge::Negation(NegationEdge {
                     source: $vertex_name::$v,
                     target: $vertex_name::$n,
                 }));)*

--- a/benches/benchmark_solver.rs
+++ b/benches/benchmark_solver.rs
@@ -1,7 +1,7 @@
 use atl_checker::algorithms::certain_zero::distributed_certain_zero;
 use atl_checker::algorithms::certain_zero::search_strategy::bfs::BreadthFirstSearchBuilder;
 use atl_checker::atl::Phi;
-use atl_checker::edg::atlcgsedg::{AtlDependencyGraph, AtlVertex};
+use atl_checker::edg::{AtlDependencyGraph, AtlVertex};
 use atl_checker::game_structure::lcgs::ir::intermediate::IntermediateLcgs;
 use atl_checker::game_structure::lcgs::parse::parse_lcgs;
 use atl_checker::game_structure::EagerGameStructure;

--- a/benches/benchmark_solver.rs
+++ b/benches/benchmark_solver.rs
@@ -1,7 +1,7 @@
 use atl_checker::algorithms::certain_zero::distributed_certain_zero;
 use atl_checker::algorithms::certain_zero::search_strategy::bfs::BreadthFirstSearchBuilder;
 use atl_checker::atl::Phi;
-use atl_checker::edg::atlcgsedg::{ATLDependencyGraph, ATLVertex};
+use atl_checker::edg::atlcgsedg::{AtlDependencyGraph, AtlVertex};
 use atl_checker::game_structure::lcgs::ir::intermediate::IntermediateLcgs;
 use atl_checker::game_structure::lcgs::parse::parse_lcgs;
 use atl_checker::game_structure::EagerGameStructure;

--- a/benches/benchmark_solver.rs
+++ b/benches/benchmark_solver.rs
@@ -2,7 +2,7 @@ use atl_checker::algorithms::certain_zero::distributed_certain_zero;
 use atl_checker::algorithms::certain_zero::search_strategy::bfs::BreadthFirstSearchBuilder;
 use atl_checker::atl::Phi;
 use atl_checker::edg::atlcgsedg::{ATLDependencyGraph, ATLVertex};
-use atl_checker::game_structure::lcgs::ir::intermediate::IntermediateLCGS;
+use atl_checker::game_structure::lcgs::ir::intermediate::IntermediateLcgs;
 use atl_checker::game_structure::lcgs::parse::parse_lcgs;
 use atl_checker::game_structure::EagerGameStructure;
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -86,7 +86,7 @@ impl SearchStrategyOption {
                 DepthFirstSearchBuilder,
                 prioritise_back_propagation,
             ),
-            SearchStrategyOption::DHS => distributed_certain_zero(
+            SearchStrategyOption::Dhs => distributed_certain_zero(
                 edg,
                 v0,
                 worker_count,
@@ -415,7 +415,7 @@ fn get_search_strategy_from_args(args: &ArgMatches) -> Result<SearchStrategyOpti
     match args.value_of("search_strategy") {
         Some("bfs") => Ok(SearchStrategyOption::Bfs),
         Some("dfs") => Ok(SearchStrategyOption::Dfs),
-        Some("dhs") => Ok(SearchStrategyOption::DHS),
+        Some("dhs") => Ok(SearchStrategyOption::Dhs),
         Some(other) => Err(format!("Unknown search strategy '{}'. Valid search strategies: \"bfs\", \"dfs\", \"dhs\" [default is \"bfs\"]", other)),
         // Default value
         None => Ok(SearchStrategyOption::Bfs)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -39,22 +39,22 @@ const GIT_VERSION: &str = git_version!(fallback = "unknown");
 /// The formula types that the system supports
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 enum FormulaFormat {
-    JSON,
-    ATL,
+    Json,
+    Atl,
 }
 
 /// The model types that the system supports
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 enum ModelType {
-    JSON,
-    LCGS,
+    Json,
+    Lcgs,
 }
 
 /// Valid search strategies options
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 enum SearchStrategyOption {
-    BFS,
-    DFS,
+    Bfs,
+    Dfs,
     DHS,
 }
 
@@ -71,14 +71,14 @@ impl SearchStrategyOption {
         prioritise_back_propagation: bool,
     ) -> VertexAssignment {
         match self {
-            SearchStrategyOption::BFS => distributed_certain_zero(
+            SearchStrategyOption::Bfs => distributed_certain_zero(
                 edg,
                 v0,
                 worker_count,
                 BreadthFirstSearchBuilder,
                 prioritise_back_propagation,
             ),
-            SearchStrategyOption::DFS => distributed_certain_zero(
+            SearchStrategyOption::Dfs => distributed_certain_zero(
                 edg,
                 v0,
                 worker_count,
@@ -117,7 +117,7 @@ fn main_inner() -> Result<(), String> {
             let input_model_path = index_args.value_of("input_model").unwrap();
             let model_type = get_model_type_from_args(&index_args)?;
 
-            if model_type != ModelType::LCGS {
+            if model_type != ModelType::Lcgs {
                 return Err("The 'index' command is only valid for LCGS models".to_string());
             }
 
@@ -353,11 +353,11 @@ fn load_formula<A: AtlExpressionParser>(path: &str, format: FormulaFormat, expr_
     });
 
     match format {
-        FormulaFormat::JSON => serde_json::from_str(raw_phi.as_str()).unwrap_or_else(|err| {
+        FormulaFormat::Json => serde_json::from_str(raw_phi.as_str()).unwrap_or_else(|err| {
             eprintln!("Failed to deserialize formula\n\nError:\n{}", err);
             exit(1);
         }),
-        FormulaFormat::ATL => {
+        FormulaFormat::Atl => {
             let result = atl_checker::atl::parse_phi(expr_parser, &raw_phi);
             result.unwrap_or_else(|err| {
                 eprintln!("Invalid ATL formula provided:\n\n{}", err);
@@ -371,15 +371,15 @@ fn load_formula<A: AtlExpressionParser>(path: &str, format: FormulaFormat, expr_
 /// --model_type argument or inferring it from the model's path extension.  
 fn get_model_type_from_args(args: &ArgMatches) -> Result<ModelType, String> {
     match args.value_of("model_type") {
-        Some("lcgs") => Ok(ModelType::LCGS),
-        Some("json") => Ok(ModelType::JSON),
+        Some("lcgs") => Ok(ModelType::Lcgs),
+        Some("json") => Ok(ModelType::Json),
         None => {
             // Infer model type from file extension
             let model_path = args.value_of("input_model").unwrap();
             if model_path.ends_with(".lcgs") {
-                Ok(ModelType::LCGS)
+                Ok(ModelType::Lcgs)
             } else if model_path.ends_with(".json") {
-                Ok(ModelType::JSON)
+                Ok(ModelType::Json)
             } else {
                 Err("Cannot infer model type from file the extension. You can specify it with '--model_type=MODEL_TYPE'".to_string())
             }
@@ -392,15 +392,15 @@ fn get_model_type_from_args(args: &ArgMatches) -> Result<ModelType, String> {
 /// --formula_format argument. If none is given, we try to infer it from the file extension
 fn get_formula_format_from_args(args: &ArgMatches) -> Result<FormulaFormat, String> {
     match args.value_of("formula_format") {
-        Some("json") => Ok(FormulaFormat::JSON),
-        Some("atl") => Ok(FormulaFormat::ATL),
+        Some("json") => Ok(FormulaFormat::Json),
+        Some("atl") => Ok(FormulaFormat::Atl),
         None => {
             // Infer format from file extension
             let formula_path = args.value_of("formula").unwrap();
             if formula_path.ends_with(".atl") {
-                Ok(FormulaFormat::ATL)
+                Ok(FormulaFormat::Atl)
             } else if formula_path.ends_with(".json") {
-                Ok(FormulaFormat::JSON)
+                Ok(FormulaFormat::Json)
             } else {
                 Err("Cannot infer formula format from file the extension. You can specify it with '--model_type=MODEL_TYPE'".to_string())
             }
@@ -412,12 +412,12 @@ fn get_formula_format_from_args(args: &ArgMatches) -> Result<FormulaFormat, Stri
 /// Determine the search strategy by reading the --search-strategy argument. Default is BFS.
 fn get_search_strategy_from_args(args: &ArgMatches) -> Result<SearchStrategyOption, String> {
     match args.value_of("search_strategy") {
-        Some("bfs") => Ok(SearchStrategyOption::BFS),
-        Some("dfs") => Ok(SearchStrategyOption::DFS),
+        Some("bfs") => Ok(SearchStrategyOption::Bfs),
+        Some("dfs") => Ok(SearchStrategyOption::Dfs),
         Some("dhs") => Ok(SearchStrategyOption::DHS),
         Some(other) => Err(format!("Unknown search strategy '{}'. Valid search strategies: \"bfs\", \"dfs\", \"dhs\" [default is \"bfs\"]", other)),
         // Default value
-        None => Ok(SearchStrategyOption::BFS)
+        None => Ok(SearchStrategyOption::Bfs)
     }
 }
 
@@ -444,7 +444,7 @@ where
 
     // Depending on which model_type is specified, use the relevant parsing logic
     match model_type {
-        ModelType::JSON => {
+        ModelType::Json => {
             let game_structure = serde_json::from_str(content.as_str())
                 .map_err(|err| format!("Failed to deserialize input model.\n{}", err))?;
 
@@ -452,7 +452,7 @@ where
 
             Ok(handle_json(game_structure, phi))
         }
-        ModelType::LCGS => {
+        ModelType::Lcgs => {
             let lcgs = parse_lcgs(&content)
                 .map_err(|err| format!("Failed to parse the LCGS program.\n{}", err))?;
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -22,7 +22,8 @@ use atl_checker::algorithms::certain_zero::search_strategy::dependency_heuristic
 use atl_checker::algorithms::certain_zero::search_strategy::dfs::DepthFirstSearchBuilder;
 use atl_checker::analyse::analyse;
 use atl_checker::atl::{AtlExpressionParser, Phi};
-use atl_checker::edg::{AtlDependencyGraph, AtlVertex, ExtendedDependencyGraph, Vertex};
+use atl_checker::edg::atlcgsedg::{AtlDependencyGraph, AtlVertex};
+use atl_checker::edg::{ExtendedDependencyGraph, Vertex};
 use atl_checker::game_structure::lcgs::ast::DeclKind;
 use atl_checker::game_structure::lcgs::ir::intermediate::IntermediateLcgs;
 use atl_checker::game_structure::lcgs::ir::symbol_table::Owner;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -21,7 +21,7 @@ use atl_checker::algorithms::certain_zero::search_strategy::bfs::BreadthFirstSea
 use atl_checker::algorithms::certain_zero::search_strategy::dependency_heuristic::DependencyHeuristicSearchBuilder;
 use atl_checker::algorithms::certain_zero::search_strategy::dfs::DepthFirstSearchBuilder;
 use atl_checker::analyse::analyse;
-use atl_checker::atl::{ATLExpressionParser, Phi};
+use atl_checker::atl::{AtlExpressionParser, Phi};
 use atl_checker::edg::{AtlDependencyGraph, AtlVertex, ExtendedDependencyGraph, Vertex};
 use atl_checker::game_structure::lcgs::ast::DeclKind;
 use atl_checker::game_structure::lcgs::ir::intermediate::IntermediateLcgs;
@@ -340,7 +340,7 @@ fn main_inner() -> Result<(), String> {
 /// Reads a formula in JSON format from a file and returns the formula as a string
 /// and as a parsed Phi struct.
 /// This function will exit the program if it encounters an error.
-fn load_formula<A: ATLExpressionParser>(path: &str, format: FormulaFormat, expr_parser: &A) -> Phi {
+fn load_formula<A: AtlExpressionParser>(path: &str, format: FormulaFormat, expr_parser: &A) -> Phi {
     let mut file = File::open(path).unwrap_or_else(|err| {
         eprintln!("Failed to open formula file\n\nError:\n{}", err);
         exit(1);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -22,8 +22,7 @@ use atl_checker::algorithms::certain_zero::search_strategy::dependency_heuristic
 use atl_checker::algorithms::certain_zero::search_strategy::dfs::DepthFirstSearchBuilder;
 use atl_checker::analyse::analyse;
 use atl_checker::atl::{ATLExpressionParser, Phi};
-use atl_checker::edg::atlcgsedg::{ATLDependencyGraph, ATLVertex};
-use atl_checker::edg::{ExtendedDependencyGraph, Vertex};
+use atl_checker::edg::{AtlDependencyGraph, AtlVertex, ExtendedDependencyGraph, Vertex};
 use atl_checker::game_structure::lcgs::ast::DeclKind;
 use atl_checker::game_structure::lcgs::ir::intermediate::IntermediateLcgs;
 use atl_checker::game_structure::lcgs::ir::symbol_table::Owner;
@@ -165,8 +164,8 @@ fn main_inner() -> Result<(), String> {
 
             // Generic start function for use with `load` that start model checking with `distributed_certain_zero`
             fn check_model<G>(
-                graph: ATLDependencyGraph<G>,
-                v0: ATLVertex,
+                graph: AtlDependencyGraph<G>,
+                v0: AtlVertex,
                 threads: u64,
                 ss: SearchStrategyOption,
                 prioritise_back_propagation: bool,
@@ -193,11 +192,11 @@ fn main_inner() -> Result<(), String> {
                         "Checking the formula: {}",
                         formula.in_context_of(&game_structure)
                     );
-                    let v0 = ATLVertex::FULL {
+                    let v0 = AtlVertex::Full {
                         state: 0,
                         formula: Arc::from(formula),
                     };
-                    let graph = ATLDependencyGraph { game_structure };
+                    let graph = AtlDependencyGraph { game_structure };
                     check_model(
                         graph,
                         v0,
@@ -212,8 +211,8 @@ fn main_inner() -> Result<(), String> {
                         formula.in_context_of(&game_structure)
                     );
                     let arc = Arc::from(formula);
-                    let graph = ATLDependencyGraph { game_structure };
-                    let v0 = ATLVertex::FULL {
+                    let graph = AtlDependencyGraph { game_structure };
+                    let v0 = AtlVertex::Full {
                         state: graph.game_structure.initial_state_index(),
                         formula: arc,
                     };
@@ -235,9 +234,9 @@ fn main_inner() -> Result<(), String> {
 
             let output_arg = analyse_args.value_of("output").unwrap();
 
-            fn analyse_and_save<G: ExtendedDependencyGraph<ATLVertex>>(
+            fn analyse_and_save<G: ExtendedDependencyGraph<AtlVertex>>(
                 edg: &G,
-                root: ATLVertex,
+                root: AtlVertex,
                 output_path: &str,
             ) -> Result<(), String> {
                 let data = analyse(edg, root);
@@ -254,19 +253,19 @@ fn main_inner() -> Result<(), String> {
                 formula_path,
                 formula_format,
                 |game_structure, formula| {
-                    let v0 = ATLVertex::FULL {
+                    let v0 = AtlVertex::Full {
                         state: 0,
                         formula: Arc::from(formula),
                     };
-                    let graph = ATLDependencyGraph { game_structure };
+                    let graph = AtlDependencyGraph { game_structure };
                     analyse_and_save(&graph, v0, output_arg)
                 },
                 |game_structure, formula| {
-                    let v0 = ATLVertex::FULL {
+                    let v0 = AtlVertex::Full {
                         state: game_structure.initial_state_index(),
                         formula: Arc::from(formula),
                     };
-                    let graph = ATLDependencyGraph { game_structure };
+                    let graph = AtlDependencyGraph { game_structure };
                     analyse_and_save(&graph, v0, output_arg)
                 },
             )??
@@ -281,8 +280,8 @@ fn main_inner() -> Result<(), String> {
 
                 // Generic start function for use with `load` that starts the graph printer
                 fn print_model<G: GameStructure>(
-                    graph: ATLDependencyGraph<G>,
-                    v0: ATLVertex,
+                    graph: AtlDependencyGraph<G>,
+                    v0: AtlVertex,
                     output: Option<&str>,
                 ) {
                     use std::io::stdout;
@@ -310,11 +309,11 @@ fn main_inner() -> Result<(), String> {
                             "Printing graph for: {}",
                             formula.in_context_of(&game_structure)
                         );
-                        let v0 = ATLVertex::FULL {
+                        let v0 = AtlVertex::Full {
                             state: 0,
                             formula: Arc::from(formula),
                         };
-                        let graph = ATLDependencyGraph { game_structure };
+                        let graph = AtlDependencyGraph { game_structure };
                         print_model(graph, v0, graph_args.value_of("output"));
                     },
                     |game_structure, formula| {
@@ -323,8 +322,8 @@ fn main_inner() -> Result<(), String> {
                             formula.in_context_of(&game_structure)
                         );
                         let arc = Arc::from(formula);
-                        let graph = ATLDependencyGraph { game_structure };
-                        let v0 = ATLVertex::FULL {
+                        let graph = AtlDependencyGraph { game_structure };
+                        let v0 = AtlVertex::Full {
                             state: graph.game_structure.initial_state_index(),
                             formula: arc,
                         };

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -25,7 +25,7 @@ use atl_checker::atl::{ATLExpressionParser, Phi};
 use atl_checker::edg::atlcgsedg::{ATLDependencyGraph, ATLVertex};
 use atl_checker::edg::{ExtendedDependencyGraph, Vertex};
 use atl_checker::game_structure::lcgs::ast::DeclKind;
-use atl_checker::game_structure::lcgs::ir::intermediate::IntermediateLCGS;
+use atl_checker::game_structure::lcgs::ir::intermediate::IntermediateLcgs;
 use atl_checker::game_structure::lcgs::ir::symbol_table::Owner;
 use atl_checker::game_structure::lcgs::parse::parse_lcgs;
 use atl_checker::game_structure::{EagerGameStructure, GameStructure};
@@ -134,7 +134,7 @@ fn main_inner() -> Result<(), String> {
             let lcgs = parse_lcgs(&content)
                 .map_err(|err| format!("Failed to parse the LCGS program.\n{}", err))?;
 
-            let ir = IntermediateLCGS::create(lcgs)
+            let ir = IntermediateLcgs::create(lcgs)
                 .map_err(|err| format!("Invalid LCGS program.\n{}", err))?;
 
             println!("Players:");
@@ -433,7 +433,7 @@ fn load<R, J, L>(
 ) -> Result<R, String>
 where
     J: FnOnce(EagerGameStructure, Phi) -> R,
-    L: FnOnce(IntermediateLCGS, Phi) -> R,
+    L: FnOnce(IntermediateLcgs, Phi) -> R,
 {
     // Open the input model file
     let mut file = File::open(game_structure_path)
@@ -457,7 +457,7 @@ where
             let lcgs = parse_lcgs(&content)
                 .map_err(|err| format!("Failed to parse the LCGS program.\n{}", err))?;
 
-            let game_structure = IntermediateLCGS::create(lcgs)
+            let game_structure = IntermediateLcgs::create(lcgs)
                 .map_err(|err| format!("Invalid LCGS program.\n{}", err))?;
 
             let phi = load_formula(formula_path, formula_format, &game_structure);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -56,7 +56,7 @@ enum ModelType {
 enum SearchStrategyOption {
     Bfs,
     Dfs,
-    DHS,
+    Dhs,
 }
 
 impl SearchStrategyOption {


### PR DESCRIPTION
I have tried to fix multiple clippy warnings. One of the main issues is the naming conventions which have been easily fixed, following [https://rust-lang.github.io/api-guidelines/naming.html#casing-conforms-to-rfc-430-c-case](url).
