### PR TITLE
Remove PartialMoves from edges

### DIFF
--- a/atl-checker/src/analyse.rs
+++ b/atl-checker/src/analyse.rs
@@ -1,6 +1,7 @@
 use crate::algorithms::solve_set::{minimum_solve_set, SolveSetAssignment};
 use crate::atl::Phi;
-use crate::edg::{ATLVertex, Edge, ExtendedDependencyGraph};
+use crate::edg::atlcgsedg::ATLVertex;
+use crate::edg::{Edge, ExtendedDependencyGraph};
 
 #[derive(Serialize, Deserialize)]
 #[serde(tag = "type")]

--- a/atl-checker/src/edg.rs
+++ b/atl-checker/src/edg.rs
@@ -17,7 +17,6 @@ pub trait ExtendedDependencyGraph<V: Vertex> {
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct HyperEdge<V: Hash + Eq + PartialEq + Clone> {
     pub source: V,
-    pub pmove: Option<PartialMove>,
     pub targets: Vec<V>,
 }
 
@@ -345,7 +344,6 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                     // Hyper edge with no targets
                     vec![Edge::HYPER(HyperEdge {
                         source: vert.clone(),
-                        pmove: None,
                         targets: vec![],
                     })]
                 }
@@ -358,7 +356,6 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                     if props.contains(prop) {
                         vec![Edge::HYPER(HyperEdge {
                             source: vert.clone(),
-                            pmove: None,
                             targets: vec![],
                         })]
                     } else {
@@ -378,7 +375,6 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                     vec![
                         Edge::HYPER(HyperEdge {
                             source: vert.clone(),
-                            pmove: None,
                             targets: vec![ATLVertex::FULL {
                                 state: *state,
                                 formula: left.clone(),
@@ -386,7 +382,6 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                         }),
                         Edge::HYPER(HyperEdge {
                             source: vert.clone(),
-                            pmove: None,
                             targets: vec![ATLVertex::FULL {
                                 state: *state,
                                 formula: right.clone(),
@@ -397,7 +392,6 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                 Phi::And(left, right) => {
                     vec![Edge::HYPER(HyperEdge {
                         source: vert.clone(),
-                        pmove: None,
                         targets: vec![
                             ATLVertex::FULL {
                                 state: *state,
@@ -423,7 +417,6 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
 
                     vec![Edge::HYPER(HyperEdge {
                         source: vert.clone(),
-                        pmove: None,
                         targets,
                     })]
                 }
@@ -440,7 +433,6 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                                     .collect();
                             Edge::HYPER(HyperEdge {
                                 source: vert.clone(),
-                                pmove: Some(pmove),
                                 targets,
                             })
                         })
@@ -479,7 +471,6 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                         // This must be the first edge
                         Edge::HYPER(HyperEdge {
                             source: vert.clone(),
-                            pmove: None,
                             targets: vec![ATLVertex::FULL {
                                 state: *state,
                                 formula: until.clone(),
@@ -488,7 +479,6 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                         // Other branches where pre is satisfied
                         Edge::HYPER(HyperEdge {
                             source: vert.clone(),
-                            pmove: None,
                             targets,
                         }),
                     ]
@@ -504,7 +494,6 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                         // This must be the first edge
                         Edge::HYPER(HyperEdge {
                             source: vert.clone(),
-                            pmove: None,
                             targets: vec![ATLVertex::FULL {
                                 state: *state,
                                 formula: until.clone(),
@@ -536,7 +525,6 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                                     std::iter::once(pre.clone()).chain(delta).collect();
                                 Edge::HYPER(HyperEdge {
                                     source: vert.clone(),
-                                    pmove: Some(pmove),
                                     targets,
                                 })
                             },
@@ -567,7 +555,6 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                         // This must be the first edge
                         Edge::HYPER(HyperEdge {
                             source: vert.clone(),
-                            pmove: None,
                             targets: vec![ATLVertex::FULL {
                                 state: *state,
                                 formula: subformula.clone(),
@@ -575,7 +562,6 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                         }),
                         Edge::HYPER(HyperEdge {
                             source: vert.clone(),
-                            pmove: None,
                             targets,
                         }),
                     ]
@@ -590,7 +576,6 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                         // This must be the first edge
                         Edge::HYPER(HyperEdge {
                             source: vert.clone(),
-                            pmove: None,
                             targets: vec![ATLVertex::FULL {
                                 state: *state,
                                 formula: subformula.clone(),
@@ -613,7 +598,6 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                                         .collect();
                                 Edge::HYPER(HyperEdge {
                                     source: vert.clone(),
-                                    pmove: Some(pmove),
                                     targets,
                                 })
                             },
@@ -669,7 +653,6 @@ impl<G: GameStructure> ExtendedDependencyGraph<ATLVertex> for ATLDependencyGraph
                     }];
                     Edge::HYPER(HyperEdge {
                         source: vert.clone(),
-                        pmove: Some(partial_move.clone()),
                         targets,
                     })
                 })

--- a/atl-checker/src/edg/atlcgsedg.rs
+++ b/atl-checker/src/edg/atlcgsedg.rs
@@ -4,33 +4,8 @@ use std::hash::Hash;
 use std::sync::Arc;
 
 use crate::atl::Phi;
+use crate::edg::{Edge, ExtendedDependencyGraph, HyperEdge, NegationEdge, Vertex};
 use crate::game_structure::{GameStructure, Player, State};
-
-pub trait Vertex: Hash + Eq + PartialEq + Clone + Display + Debug {}
-
-pub trait ExtendedDependencyGraph<V: Vertex> {
-    /// Return out going edges from `vertex`.
-    /// This will be cached on each worker.
-    fn succ(&self, vertex: &V) -> Vec<Edge<V>>;
-}
-
-#[derive(Clone, Eq, PartialEq, Hash, Debug)]
-pub struct HyperEdge<V: Hash + Eq + PartialEq + Clone> {
-    pub source: V,
-    pub targets: Vec<V>,
-}
-
-#[derive(Clone, Eq, PartialEq, Hash, Debug)]
-pub struct NegationEdge<V: Hash + Eq + PartialEq + Clone> {
-    pub source: V,
-    pub target: V,
-}
-
-#[derive(Clone, Eq, PartialEq, Hash, Debug)]
-pub enum Edge<V: Hash + Eq + PartialEq + Clone> {
-    HYPER(HyperEdge<V>),
-    NEGATION(NegationEdge<V>),
-}
 
 #[derive(Clone, Debug)]
 pub struct ATLDependencyGraph<G: GameStructure> {
@@ -666,7 +641,9 @@ mod test {
     use std::collections::HashSet;
     use std::sync::Arc;
 
-    use crate::edg::{DeltaIterator, PartialMoveChoice, PartialMoveIterator, PmovesIterator};
+    use crate::edg::atlcgsedg::{
+        DeltaIterator, PartialMoveChoice, PartialMoveIterator, PmovesIterator,
+    };
     use crate::game_structure::{DynVec, EagerGameStructure};
 
     #[test]

--- a/atl-checker/src/edg/mod.rs
+++ b/atl-checker/src/edg/mod.rs
@@ -1,0 +1,30 @@
+use std::fmt::{Debug, Display};
+use std::hash::Hash;
+
+pub mod atlcgsedg;
+
+pub trait Vertex: Hash + Eq + PartialEq + Clone + Display + Debug {}
+
+pub trait ExtendedDependencyGraph<V: Vertex> {
+    /// Return out going edges from `vertex`.
+    /// This will be cached on each worker.
+    fn succ(&self, vertex: &V) -> Vec<Edge<V>>;
+}
+
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+pub struct HyperEdge<V: Hash + Eq + PartialEq + Clone> {
+    pub source: V,
+    pub targets: Vec<V>,
+}
+
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+pub struct NegationEdge<V: Hash + Eq + PartialEq + Clone> {
+    pub source: V,
+    pub target: V,
+}
+
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+pub enum Edge<V: Hash + Eq + PartialEq + Clone> {
+    HYPER(HyperEdge<V>),
+    NEGATION(NegationEdge<V>),
+}

--- a/atl-checker/src/simple_edg.rs
+++ b/atl-checker/src/simple_edg.rs
@@ -80,7 +80,6 @@ macro_rules! simple_edg {
                 let mut successors = vec![];
                 $(successors.push(Edge::HYPER(HyperEdge {
                     source: $vertex_name::$v,
-                    pmove: None,
                     targets: vec![$($vertex_name::$t),*],
                 }));)*
                 $(successors.push(Edge::NEGATION(NegationEdge {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -21,7 +21,8 @@ use atl_checker::algorithms::certain_zero::search_strategy::bfs::BreadthFirstSea
 use atl_checker::algorithms::certain_zero::search_strategy::dfs::DepthFirstSearchBuilder;
 use atl_checker::analyse::analyse;
 use atl_checker::atl::{ATLExpressionParser, Phi};
-use atl_checker::edg::{ATLDependencyGraph, ATLVertex, ExtendedDependencyGraph, Vertex};
+use atl_checker::edg::atlcgsedg::{ATLDependencyGraph, ATLVertex};
+use atl_checker::edg::{ExtendedDependencyGraph, Vertex};
 use atl_checker::game_structure::lcgs::ast::DeclKind;
 use atl_checker::game_structure::lcgs::ir::intermediate::IntermediateLCGS;
 use atl_checker::game_structure::lcgs::ir::symbol_table::Owner;


### PR DESCRIPTION
I previously thought that annotating edges with partial moves would help us computer the partial strategy. However, I have found a different way to do it, so now I remove them again.

This also allows us to separate general EDGs from ATL/CGS.