### PR TITLE
Add quiet flag and exitcode output

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -208,8 +208,7 @@ fn main_inner() -> Result<(), String> {
                 formula_path,
                 formula_format,
                 |game_structure, formula| {
-                    if solver_args.is_present("quiet") {
-                    } else {
+                    if !solver_args.is_present("quiet") {
                         println!(
                             "Checking the formula: {}",
                             formula.in_context_of(&game_structure)
@@ -232,8 +231,7 @@ fn main_inner() -> Result<(), String> {
                     );
                 },
                 |game_structure, formula| {
-                    if solver_args.is_present("quiet") {
-                    } else {
+                    if !solver_args.is_present("quiet") {
                         println!(
                             "Checking the formula: {}",
                             formula.in_context_of(&game_structure)
@@ -536,7 +534,7 @@ fn parse_arguments() -> ArgMatches<'static> {
                         .takes_value(false)
                         .long("quiet")
                         .help(
-                            "Suppress stdout and return exitcode 42 for true result or 43 for false",
+                            "Suppress stdout and only return exitcode 42 for true result or 43 for false",
                         ),
                 ),
         )

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -222,7 +222,7 @@ fn main_inner() -> Result<(), String> {
                             prioritise_back_propagation,
                         ),
                     };
-                    println!("Result: {}", result);
+                    quiet_output_handle(result, solver_args.is_present("quiet"));
                     Ok(())
                 },
                 |game_structure, formula| {
@@ -257,7 +257,7 @@ fn main_inner() -> Result<(), String> {
                             prioritise_back_propagation,
                         ),
                     };
-                    println!("Result: {}", result);
+                    quiet_output_handle(result, solver_args.is_present("quiet"));
                     Ok(())
                 },
             )??


### PR DESCRIPTION
- Add `-q | --quiet` flag 
- Only print "checking on formula: e, satisfies: true|false" to stdout if quiet-flag is unset
- If quiet-flag is set, return exitcodes 42=true 43=false

This functionality is useful for shell-scripting usage cases of CGAAL.

Also reworded "Result:" -> "Model satisfies formula:" for accuracy