### PR TITLE
[P8-111] Actual linear programming search

### DIFF
--- a/atl-checker/src/algorithms/certain_zero/search_strategy/linear_constrained_phi.rs
+++ b/atl-checker/src/algorithms/certain_zero/search_strategy/linear_constrained_phi.rs
@@ -1,0 +1,210 @@
+use crate::algorithms::certain_zero::search_strategy::linear_constraints::{
+    ComparisonOp, LinearConstraint, LinearConstraintExtractor,
+};
+use crate::atl::Phi;
+use crate::game_structure::lcgs::ast::{
+    BinaryOpKind, DeclKind, Expr, ExprKind, Identifier, UnaryOpKind,
+};
+use crate::game_structure::lcgs::ir::intermediate::IntermediateLcgs;
+use crate::game_structure::lcgs::ir::symbol_table::SymbolIdentifier;
+use crate::game_structure::Proposition;
+use std::borrow::{Borrow, BorrowMut};
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+/// A structure describing the relation between linear constraints in a ATL formula
+#[derive(Clone)]
+pub enum LinearConstrainedPhi {
+    /// Either or should hold
+    Or(Box<LinearConstrainedPhi>, Box<LinearConstrainedPhi>),
+    /// Both should hold
+    And(Box<LinearConstrainedPhi>, Box<LinearConstrainedPhi>),
+    /// Mapping symbols to ranges
+    Constraint(LinearConstraint),
+    True,
+    False,
+}
+
+pub struct ConstrainedPhiMapper {
+    /// Cached LinearConstrainedPhi of propositions
+    proposition_cache: RefCell<HashMap<Proposition, LinearConstrainedPhi>>,
+}
+
+impl ConstrainedPhiMapper {
+    pub fn new() -> ConstrainedPhiMapper {
+        ConstrainedPhiMapper {
+            proposition_cache: RefCell::new(HashMap::new()),
+        }
+    }
+
+    /// Map the given phi to a linear constrained phi. Propositions will be map based on the given
+    /// game and they will be cached, so the same game should be used every time.
+    pub fn map(&self, game: &IntermediateLcgs, phi: &Phi) -> LinearConstrainedPhi {
+        self.map_phi_to_constraints(game, phi)
+    }
+
+    /// Takes a phi and maps it to a LinearConstrainedPhi
+    fn map_phi_to_constraints(&self, game: &IntermediateLcgs, phi: &Phi) -> LinearConstrainedPhi {
+        match phi {
+            Phi::True => LinearConstrainedPhi::True,
+            Phi::False => LinearConstrainedPhi::False,
+            Phi::Proposition(proposition) => {
+                // If we get to a proposition, continue the mapping inside the proposition's condition
+                // The result may be cached
+                let maybe_constraint = self.proposition_cache.borrow().get(proposition).cloned();
+                maybe_constraint.unwrap_or_else(|| {
+                    // We have not mapped this proposition yet
+                    let decl = game.label_index_to_decl(*proposition);
+                    if let DeclKind::Label(label) = &decl.kind {
+                        let mapped_expr = self.map_expr_to_constraints(&label.condition);
+                        // Save result in cache
+                        self.proposition_cache
+                            .borrow_mut()
+                            .insert(*proposition, mapped_expr.clone());
+                        mapped_expr
+                    } else {
+                        panic!("Non-propositions symbol in ATL formula")
+                    }
+                })
+            }
+            Phi::Not(formula) => self.map_phi_to_constraints(game, formula),
+            Phi::Or(lhs, rhs) => {
+                let lhs_symbol_range_map = self.map_phi_to_constraints(game, lhs);
+                let rhs_symbol_range_map = self.map_phi_to_constraints(game, rhs);
+
+                LinearConstrainedPhi::Or(
+                    Box::from(lhs_symbol_range_map),
+                    Box::from(rhs_symbol_range_map),
+                )
+            }
+            Phi::And(lhs, rhs) => {
+                let lhs_symbol_range_map = self.map_phi_to_constraints(game, lhs);
+                let rhs_symbol_range_map = self.map_phi_to_constraints(game, rhs);
+
+                LinearConstrainedPhi::And(
+                    Box::from(lhs_symbol_range_map),
+                    Box::from(rhs_symbol_range_map),
+                )
+            }
+            Phi::DespiteNext { formula, .. } => self.map_phi_to_constraints(game, formula),
+            Phi::EnforceNext { formula, .. } => self.map_phi_to_constraints(game, formula),
+            Phi::DespiteUntil { pre, until, .. } => {
+                let pre_symbol_range_map = self.map_phi_to_constraints(game, pre);
+                let until_symbol_range_map = self.map_phi_to_constraints(game, until);
+
+                LinearConstrainedPhi::Or(
+                    Box::from(pre_symbol_range_map),
+                    Box::from(until_symbol_range_map),
+                )
+            }
+            Phi::EnforceUntil { pre, until, .. } => {
+                let pre_symbol_range_map = self.map_phi_to_constraints(game, pre);
+                let until_symbol_range_map = self.map_phi_to_constraints(game, until);
+
+                LinearConstrainedPhi::Or(
+                    Box::from(pre_symbol_range_map),
+                    Box::from(until_symbol_range_map),
+                )
+            }
+            Phi::DespiteEventually { formula, .. } => self.map_phi_to_constraints(game, formula),
+            Phi::EnforceEventually { formula, .. } => self.map_phi_to_constraints(game, formula),
+            Phi::DespiteInvariant { formula, .. } => self.map_phi_to_constraints(game, formula),
+            Phi::EnforceInvariant { formula, .. } => self.map_phi_to_constraints(game, formula),
+        }
+    }
+
+    /// Takes an expression and maps it to a LinearConstrainedPhi
+    fn map_expr_to_constraints(&self, expr: &Expr) -> LinearConstrainedPhi {
+        match &expr.kind {
+            ExprKind::UnaryOp(UnaryOpKind::Not, sub_expr) => {
+                return self.map_expr_to_constraints(sub_expr);
+            }
+            ExprKind::BinaryOp(operator, lhs, rhs) => {
+                match operator {
+                    BinaryOpKind::Equality
+                    | BinaryOpKind::GreaterThan
+                    | BinaryOpKind::GreaterOrEqual
+                    | BinaryOpKind::LessThan
+                    | BinaryOpKind::LessOrEqual => {
+                        let lin_expr = LinearConstraintExtractor::extract(expr);
+                        return if let Some(lin_expr) = lin_expr {
+                            LinearConstrainedPhi::Constraint(lin_expr)
+                        } else {
+                            // Not linear
+                            LinearConstrainedPhi::True
+                        };
+                    }
+                    BinaryOpKind::And => {
+                        let lhs_con = self.map_expr_to_constraints(lhs);
+                        let rhs_con = self.map_expr_to_constraints(rhs);
+                        return LinearConstrainedPhi::And(Box::new(lhs_con), Box::new(rhs_con));
+                    }
+                    BinaryOpKind::Or => {
+                        let lhs_con = self.map_expr_to_constraints(lhs);
+                        let rhs_con = self.map_expr_to_constraints(rhs);
+                        return LinearConstrainedPhi::Or(Box::new(lhs_con), Box::new(rhs_con));
+                    }
+                    // P -> Q == not P v Q, we don't care about not, so becomes P v Q
+                    BinaryOpKind::Implication => {
+                        let lhs_con = self.map_expr_to_constraints(lhs);
+                        let rhs_con = self.map_expr_to_constraints(rhs);
+                        return LinearConstrainedPhi::Or(Box::new(lhs_con), Box::new(rhs_con));
+                    }
+                    _ => {}
+                }
+            }
+            ExprKind::Number(n) => {
+                return if *n == 0 {
+                    LinearConstrainedPhi::False
+                } else {
+                    LinearConstrainedPhi::True
+                }
+            }
+            // https://en.wikipedia.org/wiki/Conditioned_disjunction
+            // Q ? P : R == (Q -> P) and (not Q -> R) == (Q and P) or (not Q and R)
+            // we don't care about not, so becomes (Q and P) or (Q and R), and can be written as
+            // (Q and (P or R))
+            ExprKind::TernaryIf(q, p, r) => {
+                let q = self.map_expr_to_constraints(q);
+                let p = self.map_expr_to_constraints(p);
+                let r = self.map_expr_to_constraints(r);
+                return LinearConstrainedPhi::And(
+                    Box::new(q),
+                    Box::from(LinearConstrainedPhi::Or(Box::new(p), Box::new(r))),
+                );
+            }
+            // Some other expression can be converted to a comparisons since everything != 0 is true
+            ExprKind::OwnedIdent(ident) => {
+                let mut terms_hashmap = HashMap::new();
+                if let Identifier::Resolved { owner, name } = ident.as_ref() {
+                    terms_hashmap.insert(owner.symbol_id(name), 1.0);
+                }
+
+                let less_constraint = LinearConstraint {
+                    terms: terms_hashmap.clone(),
+                    constant: 0.0,
+                    comparison: ComparisonOp::Less,
+                    coefficient_norm: 1.0,
+                };
+
+                let greater_constraint = LinearConstraint {
+                    terms: terms_hashmap,
+                    constant: 0.0,
+                    comparison: ComparisonOp::Greater,
+                    coefficient_norm: 1.0,
+                };
+
+                return LinearConstrainedPhi::Or(
+                    Box::new(LinearConstrainedPhi::Constraint(less_constraint)),
+                    Box::new(LinearConstrainedPhi::Constraint(greater_constraint)),
+                );
+            }
+
+            _ => {}
+        }
+
+        // Not linear
+        LinearConstrainedPhi::True
+    }
+}

--- a/atl-checker/src/algorithms/certain_zero/search_strategy/linear_constrained_phi.rs
+++ b/atl-checker/src/algorithms/certain_zero/search_strategy/linear_constrained_phi.rs
@@ -6,12 +6,9 @@ use crate::game_structure::lcgs::ast::{
     BinaryOpKind, DeclKind, Expr, ExprKind, Identifier, UnaryOpKind,
 };
 use crate::game_structure::lcgs::ir::intermediate::IntermediateLcgs;
-use crate::game_structure::lcgs::ir::symbol_table::SymbolIdentifier;
 use crate::game_structure::Proposition;
-use std::borrow::{Borrow, BorrowMut};
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::rc::Rc;
 
 /// A structure describing the relation between linear constraints in a ATL formula
 #[derive(Clone)]
@@ -27,26 +24,6 @@ pub enum LinearConstrainedPhi {
     NonLinear,
     True,
     False,
-}
-
-impl LinearConstrainedPhi {
-    /// Change this constrained phi to its negation
-    pub fn negated(&self) -> Self {
-        match self {
-            LinearConstrainedPhi::Or(lhs, rhs) => {
-                LinearConstrainedPhi::And(Box::new(lhs.negate()), Box::new(rhs.negate()))
-            }
-            LinearConstrainedPhi::And(lhs, rhs) => {
-                LinearConstrainedPhi::Or(Box::new(lhs.negate()), Box::new(rhs.negate()))
-            }
-            LinearConstrainedPhi::Constraint(constraint) => {
-                LinearConstrainedPhi::Constraint(constraint.negated())
-            }
-            LinearConstrainedPhi::True => LinearConstrainedPhi::False,
-            LinearConstrainedPhi::False => LinearConstrainedPhi::True,
-            LinearConstrainedPhi::NonLinear => LinearConstrainedPhi::NonLinear,
-        }
-    }
 }
 
 pub struct ConstrainedPhiMapper {
@@ -234,13 +211,13 @@ impl ConstrainedPhiMapper {
                 let r = self.map_expr_to_constraints(r, negated);
                 return if !negated {
                     LinearConstrainedPhi::Or(
-                        Box::new(LinearConstrainedPhi::And(Box::new(q), Box::new(p))),
-                        Box::from(LinearConstrainedPhi::And(Box::new(q.clone()), Box::new(r))),
+                        Box::new(LinearConstrainedPhi::And(Box::new(q.clone()), Box::new(p))),
+                        Box::from(LinearConstrainedPhi::And(Box::new(q), Box::new(r))),
                     )
                 } else {
                     LinearConstrainedPhi::And(
-                        Box::new(LinearConstrainedPhi::Or(Box::new(q), Box::new(p))),
-                        Box::from(LinearConstrainedPhi::Or(Box::new(q.clone()), Box::new(r))),
+                        Box::new(LinearConstrainedPhi::Or(Box::new(q.clone()), Box::new(p))),
+                        Box::from(LinearConstrainedPhi::Or(Box::new(q), Box::new(r))),
                     )
                 };
             }

--- a/atl-checker/src/algorithms/certain_zero/search_strategy/linear_constrained_phi.rs
+++ b/atl-checker/src/algorithms/certain_zero/search_strategy/linear_constrained_phi.rs
@@ -31,10 +31,10 @@ impl LinearConstrainedPhi {
     pub fn negated(&self) -> Self {
         match self {
             LinearConstrainedPhi::Or(lhs, rhs) => {
-                LinearConstrainedPhi::And(Box::new(lhs.negate()), Box::new(rhs.negate()))
+                LinearConstrainedPhi::And(Box::new(lhs.negated()), Box::new(rhs.negated()))
             }
             LinearConstrainedPhi::And(lhs, rhs) => {
-                LinearConstrainedPhi::Or(Box::new(lhs.negate()), Box::new(rhs.negate()))
+                LinearConstrainedPhi::Or(Box::new(lhs.negated()), Box::new(rhs.negated()))
             }
             LinearConstrainedPhi::Constraint(constraint) => {
                 LinearConstrainedPhi::Constraint(constraint.negated())

--- a/atl-checker/src/algorithms/certain_zero/search_strategy/linear_constrained_phi.rs
+++ b/atl-checker/src/algorithms/certain_zero/search_strategy/linear_constrained_phi.rs
@@ -236,9 +236,14 @@ impl ConstrainedPhiMapper {
                         Box::new(LinearConstrainedPhi::And(Box::new(not_q), Box::new(r))),
                     )
                 } else {
+                    // If negated, then we want to produce not (Q and P) or (not Q and R)
+                    // == (not (Q and P)) and (not (not Q and R))
+                    // == (not Q or not P) and (Q or not R)
+                    // And all terms are negated since negated was passed to it, so ultimately
+                    // we get (Q or P) and (not Q or R)
                     LinearConstrainedPhi::And(
-                        Box::new(LinearConstrainedPhi::Or(Box::new(not_q), Box::new(p))),
-                        Box::new(LinearConstrainedPhi::Or(Box::new(q), Box::new(r))),
+                        Box::new(LinearConstrainedPhi::Or(Box::new(q), Box::new(p))),
+                        Box::new(LinearConstrainedPhi::Or(Box::new(not_q), Box::new(r))),
                     )
                 };
             }

--- a/atl-checker/src/algorithms/certain_zero/search_strategy/linear_constraints.rs
+++ b/atl-checker/src/algorithms/certain_zero/search_strategy/linear_constraints.rs
@@ -25,6 +25,16 @@ impl Display for ComparisonOp {
     }
 }
 
+impl From<ComparisonOp> for minilp::ComparisonOp {
+    fn from(op: ComparisonOp) -> Self {
+        match op {
+            ComparisonOp::Equal => minilp::ComparisonOp::Eq,
+            ComparisonOp::Less | ComparisonOp::LessOrEq => minilp::ComparisonOp::Le,
+            ComparisonOp::Greater | ComparisonOp::GreaterOrEq => minilp::ComparisonOp::Ge,
+        }
+    }
+}
+
 /// Holds extracted linear expressions from the formula in AtlVertex
 /// E.g. `ax + by + cz + k = 0`.
 #[derive(Clone)]

--- a/atl-checker/src/algorithms/certain_zero/search_strategy/linear_constraints.rs
+++ b/atl-checker/src/algorithms/certain_zero/search_strategy/linear_constraints.rs
@@ -7,16 +7,31 @@ use std::fmt::{Display, Formatter};
 #[derive(Hash, Eq, PartialEq, Copy, Clone, Debug)]
 pub enum ComparisonOp {
     Equal,
+    NotEqual,
     Less,
     LessOrEq,
     Greater,
     GreaterOrEq,
 }
 
+impl ComparisonOp {
+    fn negated(&self) -> ComparisonOp {
+        match self {
+            ComparisonOp::Equal => ComparisonOp::NotEqual,
+            ComparisonOp::NotEqual => ComparisonOp::Equal,
+            ComparisonOp::Less => ComparisonOp::GreaterOrEq,
+            ComparisonOp::LessOrEq => ComparisonOp::Greater,
+            ComparisonOp::Greater => ComparisonOp::LessOrEq,
+            ComparisonOp::GreaterOrEq => ComparisonOp::Less,
+        }
+    }
+}
+
 impl Display for ComparisonOp {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             ComparisonOp::Equal => write!(f, "="),
+            ComparisonOp::NotEqual => writeln!(f, "!="),
             ComparisonOp::Less => write!(f, "<"),
             ComparisonOp::LessOrEq => write!(f, "<="),
             ComparisonOp::Greater => write!(f, ">"),
@@ -28,7 +43,7 @@ impl Display for ComparisonOp {
 impl From<ComparisonOp> for minilp::ComparisonOp {
     fn from(op: ComparisonOp) -> Self {
         match op {
-            ComparisonOp::Equal => minilp::ComparisonOp::Eq,
+            ComparisonOp::Equal | ComparisonOp::NotEqual => minilp::ComparisonOp::Eq,
             ComparisonOp::Less | ComparisonOp::LessOrEq => minilp::ComparisonOp::Le,
             ComparisonOp::Greater | ComparisonOp::GreaterOrEq => minilp::ComparisonOp::Ge,
         }
@@ -46,6 +61,15 @@ pub struct LinearConstraint {
     /// The norm of the coefficients. That is, if the linear expression is `ax + by + cz + k`, then
     /// this is `sqrt(a*a + b*b + c*c)`
     pub coefficient_norm: f64,
+}
+
+impl LinearConstraint {
+    /// Return a negated version of this constraint
+    pub fn negated(&self) -> Self {
+        let mut clone = self.clone();
+        clone.comparison = clone.comparison.negated();
+        clone
+    }
 }
 
 impl Display for LinearConstraint {

--- a/atl-checker/src/algorithms/certain_zero/search_strategy/linear_constraints.rs
+++ b/atl-checker/src/algorithms/certain_zero/search_strategy/linear_constraints.rs
@@ -42,6 +42,9 @@ impl Display for ComparisonOp {
 
 impl From<ComparisonOp> for minilp::ComparisonOp {
     fn from(op: ComparisonOp) -> Self {
+        // We are bound to lose some precision here, however, this should not matter for the
+        // linear programming solutions. Except for NotEqual becoming Equal, but, we don't
+        // include NotEqual's in our linear problems anyway, since they are almost always true.
         match op {
             ComparisonOp::Equal | ComparisonOp::NotEqual => minilp::ComparisonOp::Eq,
             ComparisonOp::Less | ComparisonOp::LessOrEq => minilp::ComparisonOp::Le,

--- a/atl-checker/src/algorithms/certain_zero/search_strategy/linear_optimize.rs
+++ b/atl-checker/src/algorithms/certain_zero/search_strategy/linear_optimize.rs
@@ -1,22 +1,15 @@
 use crate::algorithms::certain_zero::search_strategy::linear_constrained_phi::{
     ConstrainedPhiMapper, LinearConstrainedPhi,
 };
-use crate::algorithms::certain_zero::search_strategy::linear_constraints::{
-    ComparisonOp, LinearConstraint, LinearConstraintExtractor,
-};
+use crate::algorithms::certain_zero::search_strategy::linear_constraints::LinearConstraint;
 use crate::algorithms::certain_zero::search_strategy::{SearchStrategy, SearchStrategyBuilder};
 use crate::atl::Phi;
 use crate::edg::atlcgsedg::AtlVertex;
 use crate::edg::Edge;
-use crate::game_structure::lcgs::ast::{
-    BinaryOpKind, DeclKind, Expr, ExprKind, Identifier, UnaryOpKind,
-};
 use crate::game_structure::lcgs::ir::intermediate::{IntermediateLcgs, State};
-use crate::game_structure::Proposition;
 use crate::game_structure::State as StateUsize;
 use float_ord::FloatOrd;
 use priority_queue::PriorityQueue;
-use std::cell::RefCell;
 use std::collections::HashMap;
 use std::option::Option::Some;
 use std::sync::Arc;
@@ -174,6 +167,7 @@ impl LinearOptimizeSearch {
             }
             LinearConstrainedPhi::True => Some(FloatOrd(0.0)),
             LinearConstrainedPhi::False => None,
+            LinearConstrainedPhi::NonLinear => None,
         }
     }
 }

--- a/atl-checker/src/algorithms/certain_zero/search_strategy/linear_optimize.rs
+++ b/atl-checker/src/algorithms/certain_zero/search_strategy/linear_optimize.rs
@@ -1,3 +1,6 @@
+use crate::algorithms::certain_zero::search_strategy::linear_constrained_phi::{
+    ConstrainedPhiMapper, LinearConstrainedPhi,
+};
 use crate::algorithms::certain_zero::search_strategy::linear_constraints::{
     ComparisonOp, LinearConstraint, LinearConstraintExtractor,
 };
@@ -35,10 +38,9 @@ pub struct LinearOptimizeSearch {
     /// Priority based on distance, lowest distance highest priority
     queue: PriorityQueue<Edge<AtlVertex>, FloatOrd<f64>>,
     game: IntermediateLcgs,
+    phi_mapper: ConstrainedPhiMapper,
     /// Maps the hash of a Phi and usize of state, to a result distance
     result_cache: HashMap<(Arc<Phi>, StateUsize), FloatOrd<f64>>,
-    /// Maps proposition to the linear constraint the are
-    proposition_cache: RefCell<HashMap<Proposition, LinearConstrainedPhi>>,
     /// Maps phi to a LinearConstrainedPhi
     phi_cache: HashMap<Arc<Phi>, LinearConstrainedPhi>,
     // TODO - could add a new cache, to compare distance between states and use this to guesstimate distance
@@ -49,25 +51,12 @@ impl LinearOptimizeSearch {
     pub fn new(game: IntermediateLcgs) -> LinearOptimizeSearch {
         LinearOptimizeSearch {
             queue: PriorityQueue::new(),
+            phi_mapper: ConstrainedPhiMapper::new(),
             game,
             result_cache: HashMap::new(),
-            proposition_cache: RefCell::new(HashMap::new()),
             phi_cache: HashMap::new(),
         }
     }
-}
-
-/// A structure describing the relation between linear constraints in a ATL formula
-#[derive(Clone)]
-pub enum LinearConstrainedPhi {
-    /// Either or should hold
-    Or(Box<LinearConstrainedPhi>, Box<LinearConstrainedPhi>),
-    /// Both should hold
-    And(Box<LinearConstrainedPhi>, Box<LinearConstrainedPhi>),
-    /// Mapping symbols to ranges
-    Constraint(LinearConstraint),
-    True,
-    False,
 }
 
 impl SearchStrategy<AtlVertex> for LinearOptimizeSearch {
@@ -130,10 +119,8 @@ impl LinearOptimizeSearch {
         // If we have not seen this formula before
         if !self.phi_cache.contains_key(&target.formula()) {
             // Convert the formula to a structure of constraints
-            self.phi_cache.insert(
-                target.formula(),
-                self.map_phi_to_constraints(&*target.formula()),
-            );
+            let lcp = self.phi_mapper.map(&self.game, &*target.formula());
+            self.phi_cache.insert(target.formula(), lcp);
         }
 
         // Get constraints of this phi
@@ -151,170 +138,6 @@ impl LinearOptimizeSearch {
         }
         // If we could not find a distance, return None
         None
-    }
-
-    /// Takes a phi and maps it to a LinearConstrainedPhi
-    fn map_phi_to_constraints(&self, phi: &Phi) -> LinearConstrainedPhi {
-        match phi {
-            Phi::True => LinearConstrainedPhi::True,
-            Phi::False => LinearConstrainedPhi::False,
-            Phi::Proposition(proposition) => {
-                // If we get to a proposition, continue the mapping inside the proposition's condition
-                // The result may be cached
-                let maybe_constraint = self.proposition_cache.borrow().get(proposition).cloned();
-                maybe_constraint.unwrap_or_else(|| {
-                    // We have not mapped this proposition yet
-                    let decl = self.game.label_index_to_decl(*proposition);
-                    if let DeclKind::Label(label) = &decl.kind {
-                        let mapped_expr = self.map_expr_to_constraints(&label.condition);
-                        // Save result in cache
-                        self.proposition_cache
-                            .borrow_mut()
-                            .insert(*proposition, mapped_expr.clone());
-                        mapped_expr
-                    } else {
-                        panic!("Non-propositions symbol in ATL formula")
-                    }
-                })
-            }
-            Phi::Not(formula) => self.map_phi_to_constraints(formula),
-            Phi::Or(lhs, rhs) => {
-                let lhs_symbol_range_map = self.map_phi_to_constraints(lhs);
-                let rhs_symbol_range_map = self.map_phi_to_constraints(rhs);
-
-                LinearConstrainedPhi::Or(
-                    Box::from(lhs_symbol_range_map),
-                    Box::from(rhs_symbol_range_map),
-                )
-            }
-            Phi::And(lhs, rhs) => {
-                let lhs_symbol_range_map = self.map_phi_to_constraints(lhs);
-                let rhs_symbol_range_map = self.map_phi_to_constraints(rhs);
-
-                LinearConstrainedPhi::And(
-                    Box::from(lhs_symbol_range_map),
-                    Box::from(rhs_symbol_range_map),
-                )
-            }
-            Phi::DespiteNext { formula, .. } => self.map_phi_to_constraints(formula),
-            Phi::EnforceNext { formula, .. } => self.map_phi_to_constraints(formula),
-            Phi::DespiteUntil { pre, until, .. } => {
-                let pre_symbol_range_map = self.map_phi_to_constraints(pre);
-                let until_symbol_range_map = self.map_phi_to_constraints(until);
-
-                LinearConstrainedPhi::Or(
-                    Box::from(pre_symbol_range_map),
-                    Box::from(until_symbol_range_map),
-                )
-            }
-            Phi::EnforceUntil { pre, until, .. } => {
-                let pre_symbol_range_map = self.map_phi_to_constraints(pre);
-                let until_symbol_range_map = self.map_phi_to_constraints(until);
-
-                LinearConstrainedPhi::Or(
-                    Box::from(pre_symbol_range_map),
-                    Box::from(until_symbol_range_map),
-                )
-            }
-            Phi::DespiteEventually { formula, .. } => self.map_phi_to_constraints(formula),
-            Phi::EnforceEventually { formula, .. } => self.map_phi_to_constraints(formula),
-            Phi::DespiteInvariant { formula, .. } => self.map_phi_to_constraints(formula),
-            Phi::EnforceInvariant { formula, .. } => self.map_phi_to_constraints(formula),
-        }
-    }
-
-    /// Takes an expression and maps it to a LinearConstrainedPhi
-    fn map_expr_to_constraints(&self, expr: &Expr) -> LinearConstrainedPhi {
-        match &expr.kind {
-            ExprKind::UnaryOp(UnaryOpKind::Not, sub_expr) => {
-                return self.map_expr_to_constraints(sub_expr);
-            }
-            ExprKind::BinaryOp(operator, lhs, rhs) => {
-                match operator {
-                    BinaryOpKind::Equality
-                    | BinaryOpKind::GreaterThan
-                    | BinaryOpKind::GreaterOrEqual
-                    | BinaryOpKind::LessThan
-                    | BinaryOpKind::LessOrEqual => {
-                        let lin_expr = LinearConstraintExtractor::extract(expr);
-                        return if let Some(lin_expr) = lin_expr {
-                            LinearConstrainedPhi::Constraint(lin_expr)
-                        } else {
-                            // Not linear
-                            LinearConstrainedPhi::True
-                        };
-                    }
-                    BinaryOpKind::And => {
-                        let lhs_con = self.map_expr_to_constraints(lhs);
-                        let rhs_con = self.map_expr_to_constraints(rhs);
-                        return LinearConstrainedPhi::And(Box::new(lhs_con), Box::new(rhs_con));
-                    }
-                    BinaryOpKind::Or => {
-                        let lhs_con = self.map_expr_to_constraints(lhs);
-                        let rhs_con = self.map_expr_to_constraints(rhs);
-                        return LinearConstrainedPhi::Or(Box::new(lhs_con), Box::new(rhs_con));
-                    }
-                    // P -> Q == not P v Q, we don't care about not, so becomes P v Q
-                    BinaryOpKind::Implication => {
-                        let lhs_con = self.map_expr_to_constraints(lhs);
-                        let rhs_con = self.map_expr_to_constraints(rhs);
-                        return LinearConstrainedPhi::Or(Box::new(lhs_con), Box::new(rhs_con));
-                    }
-                    _ => {}
-                }
-            }
-            ExprKind::Number(n) => {
-                return if *n == 0 {
-                    LinearConstrainedPhi::False
-                } else {
-                    LinearConstrainedPhi::True
-                }
-            }
-            // https://en.wikipedia.org/wiki/Conditioned_disjunction
-            // Q ? P : R == (Q -> P) and (not Q -> R) == (Q and P) or (not Q and R)
-            // we don't care about not, so becomes (Q and P) or (Q and R), and can be written as
-            // (Q and (P or R))
-            ExprKind::TernaryIf(q, p, r) => {
-                let q = self.map_expr_to_constraints(q);
-                let p = self.map_expr_to_constraints(p);
-                let r = self.map_expr_to_constraints(r);
-                return LinearConstrainedPhi::And(
-                    Box::new(q),
-                    Box::from(LinearConstrainedPhi::Or(Box::new(p), Box::new(r))),
-                );
-            }
-            // Some other expression can be converted to a comparisons since everything != 0 is true
-            ExprKind::OwnedIdent(ident) => {
-                let mut terms_hashmap = HashMap::new();
-                if let Identifier::Resolved { owner, name } = ident.as_ref() {
-                    terms_hashmap.insert(owner.symbol_id(name), 1.0);
-                }
-
-                let less_constraint = LinearConstraint {
-                    terms: terms_hashmap.clone(),
-                    constant: 0.0,
-                    comparison: ComparisonOp::Less,
-                    coefficient_norm: 1.0,
-                };
-
-                let greater_constraint = LinearConstraint {
-                    terms: terms_hashmap,
-                    constant: 0.0,
-                    comparison: ComparisonOp::Greater,
-                    coefficient_norm: 1.0,
-                };
-
-                return LinearConstrainedPhi::Or(
-                    Box::new(LinearConstrainedPhi::Constraint(less_constraint)),
-                    Box::new(LinearConstrainedPhi::Constraint(greater_constraint)),
-                );
-            }
-
-            _ => {}
-        }
-
-        // Not linear
-        LinearConstrainedPhi::True
     }
 
     /// Goes through the LinearConstrainedPhi and finds how close we are to acceptance border in this state.

--- a/atl-checker/src/algorithms/certain_zero/search_strategy/linear_programming_search.rs
+++ b/atl-checker/src/algorithms/certain_zero/search_strategy/linear_programming_search.rs
@@ -17,20 +17,20 @@ use std::collections::HashMap;
 use std::option::Option::Some;
 use std::sync::Arc;
 
-/// A SearchStrategyBuilder for building the LinearOptimizeSearch strategy.
-pub struct LinearOptimizeSearchBuilder {
+/// A SearchStrategyBuilder for building the LinearProgrammingSearch strategy.
+pub struct LinearProgrammingSearchBuilder {
     pub game: IntermediateLcgs,
 }
 
-impl SearchStrategyBuilder<AtlVertex, LinearOptimizeSearch> for LinearOptimizeSearchBuilder {
-    fn build(&self) -> LinearOptimizeSearch {
-        LinearOptimizeSearch::new(self.game.clone())
+impl SearchStrategyBuilder<AtlVertex, LinearProgrammingSearch> for LinearProgrammingSearchBuilder {
+    fn build(&self) -> LinearProgrammingSearch {
+        LinearProgrammingSearch::new(self.game.clone())
     }
 }
 
 /// Search strategy using ideas from linear programming to order next vertices,
 /// based on distance from the vertex to a region that borders the line between true/false in the formula.
-pub struct LinearOptimizeSearch {
+pub struct LinearProgrammingSearch {
     /// Priority based on distance, lowest distance highest priority
     queue: PriorityQueue<Edge<AtlVertex>, i32>,
     game: IntermediateLcgs,
@@ -43,9 +43,9 @@ pub struct LinearOptimizeSearch {
     // TODO - to acceptance region, based on previous results (Mathias supervisor suggestion)
 }
 
-impl LinearOptimizeSearch {
-    pub fn new(game: IntermediateLcgs) -> LinearOptimizeSearch {
-        LinearOptimizeSearch {
+impl LinearProgrammingSearch {
+    pub fn new(game: IntermediateLcgs) -> LinearProgrammingSearch {
+        LinearProgrammingSearch {
             queue: PriorityQueue::new(),
             game,
             phi_mapper: ConstrainedPhiMapper::new(),
@@ -55,7 +55,7 @@ impl LinearOptimizeSearch {
     }
 }
 
-impl SearchStrategy<AtlVertex> for LinearOptimizeSearch {
+impl SearchStrategy<AtlVertex> for LinearProgrammingSearch {
     /// Simply returns the edge with highest priority (i.e lowest distance)
     fn next(&mut self) -> Option<Edge<AtlVertex>> {
         self.queue.pop().map(|(edge, _)| edge)
@@ -78,7 +78,7 @@ impl SearchStrategy<AtlVertex> for LinearOptimizeSearch {
     }
 }
 
-impl LinearOptimizeSearch {
+impl LinearProgrammingSearch {
     /// Finds the distance of an edge using linear programming
     fn get_distance_of_edge(&mut self, edge: &Edge<AtlVertex>) -> Option<i32> {
         let source = edge.source();

--- a/atl-checker/src/algorithms/certain_zero/search_strategy/linear_programming_search.rs
+++ b/atl-checker/src/algorithms/certain_zero/search_strategy/linear_programming_search.rs
@@ -1,0 +1,185 @@
+use crate::algorithms::certain_zero::search_strategy::linear_constraints::{
+    LinearConstraint, LinearConstraintExtractor,
+};
+use crate::algorithms::certain_zero::search_strategy::{SearchStrategy, SearchStrategyBuilder};
+use crate::atl::Phi;
+use crate::edg::atlcgsedg::AtlVertex;
+use crate::edg::Edge;
+use crate::game_structure::lcgs::ast::{BinaryOpKind, DeclKind, Expr, ExprKind, UnaryOpKind};
+use crate::game_structure::lcgs::ir::intermediate::{IntermediateLcgs, State};
+use crate::game_structure::lcgs::ir::symbol_table::SymbolIdentifier;
+use crate::game_structure::Proposition;
+use crate::game_structure::State as StateUsize;
+use float_ord::FloatOrd;
+use minilp::{LinearExpr, OptimizationDirection, Problem, Variable};
+use priority_queue::PriorityQueue;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::option::Option::Some;
+use std::sync::Arc;
+
+/// A SearchStrategyBuilder for building the LinearOptimizeSearch strategy.
+pub struct LinearOptimizeSearchBuilder {
+    pub game: IntermediateLcgs,
+}
+
+impl SearchStrategyBuilder<AtlVertex, LinearOptimizeSearch> for LinearOptimizeSearchBuilder {
+    fn build(&self) -> LinearOptimizeSearch {
+        LinearOptimizeSearch::new(self.game.clone())
+    }
+}
+
+/// Search strategy using ideas from linear programming to order next vertices,
+/// based on distance from the vertex to a region that borders the line between true/false in the formula.
+pub struct LinearOptimizeSearch {
+    /// Priority based on distance, lowest distance highest priority
+    queue: PriorityQueue<Edge<AtlVertex>, FloatOrd<f64>>,
+    game: IntermediateLcgs,
+    /// Maps the hash of a Phi and usize of state, to a result distance
+    result_cache: HashMap<(Arc<Phi>, StateUsize), f64>,
+    /// Maps proposition to the linear constraint the are
+    proposition_cache: RefCell<HashMap<Proposition, LinearConstrainedPhi>>,
+    /// Maps phi to a LinearConstrainedPhi
+    phi_cache: HashMap<Arc<Phi>, LinearConstrainedPhi>,
+    // TODO - could add a new cache, to compare distance between states and use this to guesstimate distance
+    // TODO - to acceptance region, based on previous results (Mathias supervisor suggestion)
+}
+
+impl LinearOptimizeSearch {
+    pub fn new(game: IntermediateLcgs) -> LinearOptimizeSearch {
+        LinearOptimizeSearch {
+            queue: PriorityQueue::new(),
+            game,
+            result_cache: HashMap::new(),
+            proposition_cache: RefCell::new(HashMap::new()),
+            phi_cache: HashMap::new(),
+        }
+    }
+}
+
+/// A structure describing the relation between linear constraints in a ATL formula
+#[derive(Clone)]
+pub enum LinearConstrainedPhi {
+    /// Either or should hold
+    Or(Box<LinearConstrainedPhi>, Box<LinearConstrainedPhi>),
+    /// Both should hold
+    And(Box<LinearConstrainedPhi>, Box<LinearConstrainedPhi>),
+    /// Mapping symbols to ranges
+    Constraint(LinearConstraint),
+    True,
+    False,
+}
+
+impl SearchStrategy<AtlVertex> for LinearOptimizeSearch {
+    /// Simply returns the edge with highest priority (i.e lowest distance)
+    fn next(&mut self) -> Option<Edge<AtlVertex>> {
+        self.queue.pop().map(|entry| entry.0)
+    }
+
+    /// Takes a Vec of Edges holding ATLVertices, and puts these in the queue,
+    /// based on the calculated distance from its state to acceptance region from formula
+    fn queue_new_edges(&mut self, edges: Vec<Edge<AtlVertex>>) {
+        for edge in edges {
+            let distance = self.get_distance_in_atl_vertex(edge.source());
+
+            // Add edge and distance to queue
+            if let Some(dist) = distance {
+                self.queue.push(edge, FloatOrd(-dist));
+            } else {
+                // Todo what should default value be, if cannot be calculated? For now: first priority
+                self.queue.push(edge, FloatOrd(0.0));
+            }
+        }
+    }
+}
+
+impl LinearOptimizeSearch {
+    /// Finds the distance in a single atl_vertex
+    fn get_distance_in_atl_vertex(&mut self, target: &AtlVertex) -> Option<f64> {
+        // If we have seen this phi before, and this state, get the result instantly
+        if let Some(distance) = self.result_cache.get(&(target.formula(), target.state())) {
+            return Some(*distance);
+        }
+
+        // If we have not seen this formula before
+        if !self.phi_cache.contains_key(&target.formula()) {
+            // Convert the formula to a structure of constraints
+            // TODO
+            // self.phi_cache.insert(
+            //     target.formula(),
+            //     self.map_phi_to_constraints(&*target.formula()),
+            // );
+        }
+
+        // Get constraints of this phi
+        let constrained_phi = self.phi_cache.get(&target.formula()).unwrap();
+        // Get current state in vertex
+        let state = self.game.state_from_index(target.state());
+
+        // Find the distance to constraints by visiting the constrained phi
+        if let Some(distance) = self.get_optimal_distance(constrained_phi, &state) {
+            // Cache the resulting distance from the combination of this formula and state
+            self.result_cache
+                .insert((target.formula(), target.state()), distance);
+            // Return calculated distance
+            return Some(distance);
+        }
+        // If we could not find a distance, return None
+        None
+    }
+
+    fn get_optimal_distance(
+        &self,
+        constrained_phi: &LinearConstrainedPhi,
+        state: &State,
+    ) -> Option<f64> {
+        // The LinearConstrainedPhi contains multiple variants of the linear problem due to the ORs.
+        // So we iterate through them and find the best result
+        let best = None
+        for constraints in LinearProblemConstraintIterator::new(constrained_phi) {
+            // We keep track of the symbols/variables encountered
+            let mut symbol_vars: HashMap<SymbolIdentifier, Variable> = HashMap::new();
+            let mut problem = Problem::new(OptimizationDirection::Minimize);
+
+            for constraint in &constraints {
+                // Build constraint
+                let mut lin_expr = LinearExpr::empty();
+                for (symbol, coefficient) in &constraint.terms {
+                    // Get symbol variable or register if missing
+                    let var = symbol_vars.get(&symbol).get_or_insert_with(|s| {
+                        &problem.add_var(1.0, (f64::MIN, f64::MAX)) // TODO Use symbol range from LCGS
+                    });
+                    lin_expr.add(**var, *coefficient);
+                }
+
+                problem.add_constraint(
+                    lin_expr,
+                    constraint.comparison.into(),
+                    -constraint.constant,
+                );
+            }
+
+            if let Ok(solution) = problem.solve() {
+                // Extract solution
+                // TODO
+            }
+        }
+        None
+    }
+}
+
+struct LinearProblemConstraintIterator<'a> {}
+
+impl<'a> LinearProblemConstraintIterator<'a> {
+    fn new(phi: &'a LinearConstrainedPhi) -> LinearProblemConstraintIterator<'a> {
+        LinearProblemIterator
+    }
+}
+
+impl Iterator for LinearProblemConstraintIterator {
+    type Item = Vec<LinearConstraint>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        todo!()
+    }
+}

--- a/atl-checker/src/algorithms/certain_zero/search_strategy/linear_programming_search.rs
+++ b/atl-checker/src/algorithms/certain_zero/search_strategy/linear_programming_search.rs
@@ -35,9 +35,9 @@ pub struct LinearProgrammingSearch {
     queue: PriorityQueue<Edge<AtlVertex>, i32>,
     game: IntermediateLcgs,
     phi_mapper: ConstrainedPhiMapper,
-    /// Maps the hash of a Phi and usize of state, to a result state and distance
+    /// Caches the linear programming solution state and distance of ATL vertices
     result_cache: HashMap<AtlVertex, (State, i32)>,
-    /// Maps phi to a LinearConstrainedPhi
+    /// Caches the LinearConstrainedPhi version of Phis
     phi_cache: HashMap<Arc<Phi>, LinearConstrainedPhi>,
     // TODO - could add a new cache, to compare distance between states and use this to guesstimate distance
     // TODO - to acceptance region, based on previous results (Mathias supervisor suggestion)
@@ -172,7 +172,7 @@ impl LinearProgrammingSearch {
                         best = Some((State(sol_state), man_dist));
                     }
                 } else {
-                    // We our first possible a solution
+                    // We got our first possible a solution
                     best = Some((State(sol_state), man_dist));
                 }
             }

--- a/atl-checker/src/algorithms/certain_zero/search_strategy/mod.rs
+++ b/atl-checker/src/algorithms/certain_zero/search_strategy/mod.rs
@@ -3,6 +3,7 @@ use crate::edg::{Edge, NegationEdge, Vertex};
 pub mod bfs;
 pub mod dependency_heuristic;
 pub mod dfs;
+mod linear_constrained_phi;
 mod linear_constraints;
 pub mod linear_optimize;
 pub mod linear_programming_search;

--- a/atl-checker/src/algorithms/certain_zero/search_strategy/mod.rs
+++ b/atl-checker/src/algorithms/certain_zero/search_strategy/mod.rs
@@ -5,6 +5,7 @@ pub mod dependency_heuristic;
 pub mod dfs;
 mod linear_constraints;
 pub mod linear_optimize;
+pub mod linear_programming_search;
 
 /// A SearchStrategy defines in which order safe edges of an EDG is processed first in the
 /// certain zero algorithm.

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -78,7 +78,7 @@ impl CommonArgs for App<'_, '_> {
                 .short("s")
                 .long("search-strategy")
                 .env("SEARCH_STRATEGY")
-                .help("The search strategy used {{bfs, dfs, los, dhs}}"),
+                .help("The search strategy used {{bfs, dfs, los, lps, dhs}}"),
         )
         .arg(
             Arg::with_name("no_prioritised_back_propagation")

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -21,6 +21,7 @@ use atl_checker::algorithms::certain_zero::search_strategy::bfs::BreadthFirstSea
 use atl_checker::algorithms::certain_zero::search_strategy::dependency_heuristic::DependencyHeuristicSearchBuilder;
 use atl_checker::algorithms::certain_zero::search_strategy::dfs::DepthFirstSearchBuilder;
 use atl_checker::algorithms::certain_zero::search_strategy::linear_optimize::LinearOptimizeSearchBuilder;
+use atl_checker::algorithms::certain_zero::search_strategy::linear_programming_search::LinearProgrammingSearchBuilder;
 use atl_checker::analyse::analyse;
 use atl_checker::atl::{AtlExpressionParser, Phi};
 use atl_checker::edg::atlcgsedg::{AtlDependencyGraph, AtlVertex};
@@ -56,6 +57,7 @@ enum ModelType {
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 enum SearchStrategyOption {
     Los,
+    Lps,
     Bfs,
     Dfs,
     Dhs,
@@ -75,7 +77,7 @@ impl SearchStrategyOption {
     ) -> VertexAssignment {
         match self {
             SearchStrategyOption::Los => panic!("Linear optimization cannot be called generically"),
-
+            SearchStrategyOption::Lps => panic!("Linear programming cannot be called generically"),
             SearchStrategyOption::Bfs => distributed_certain_zero(
                 edg,
                 v0,
@@ -247,6 +249,16 @@ fn main_inner() -> Result<(), String> {
                                 v0,
                                 threads,
                                 LinearOptimizeSearchBuilder { game: copy },
+                                prioritise_back_propagation,
+                            )
+                        }
+                        SearchStrategyOption::Lps => {
+                            let copy = graph.game_structure.clone();
+                            distributed_certain_zero(
+                                graph,
+                                v0,
+                                threads,
+                                LinearProgrammingSearchBuilder { game: copy },
                                 prioritise_back_propagation,
                             )
                         }
@@ -452,6 +464,7 @@ fn get_search_strategy_from_args(args: &ArgMatches) -> Result<SearchStrategyOpti
         Some("dfs") => Ok(SearchStrategyOption::Dfs),
         Some("dhs") => Ok(SearchStrategyOption::Dhs),
         Some("los") => Ok(SearchStrategyOption::Los),
+        Some("lps") => Ok(SearchStrategyOption::Lps),
         Some(other) => Err(format!("Unknown search strategy '{}'. Valid search strategies are \"bfs\", \"dfs\", \"los\", \"dhs\"  [default is \"bfs\"]", other)),
         // Default value
         None => Ok(SearchStrategyOption::Bfs)


### PR DESCRIPTION
- Adds linear programming search which priotises edges based on the source's minimal distance to satisfy the formula.
- Since linear programming also uses `LinearConstrainedPhi`, the extraction of `LinearConstrainedPhi` is now handled by `ConstrainedPhiMapper`.

Depends on #160 